### PR TITLE
feat: add SoundCloud artist verification via bio token

### DIFF
--- a/apps/web/src/app/api/verify-soundcloud/route.ts
+++ b/apps/web/src/app/api/verify-soundcloud/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  generateToken,
+  getToken,
+  consumeToken,
+  resolveProfile,
+} from "@/lib/soundcloud";
+
+/**
+ * GET /api/verify-soundcloud?username=<soundcloud_username>
+ *
+ * Generates a verification token for the given SoundCloud username.
+ * The artist should paste this token somewhere in their SoundCloud bio,
+ * then call POST to complete verification.
+ */
+export async function GET(request: NextRequest) {
+  const username = new URL(request.url).searchParams.get("username");
+
+  if (!username) {
+    return NextResponse.json(
+      { error: "username query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate that the SoundCloud user actually exists before issuing a token
+  try {
+    await resolveProfile(username);
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Could not resolve SoundCloud profile";
+    return NextResponse.json({ error: message }, { status: 404 });
+  }
+
+  const token = generateToken(username);
+
+  return NextResponse.json({
+    token,
+    username,
+    instructions:
+      `Paste "${token}" anywhere in your SoundCloud bio, then call POST /api/verify-soundcloud with { "token": "${token}" } to complete verification. The token expires in 15 minutes.`,
+  });
+}
+
+/**
+ * POST /api/verify-soundcloud
+ * Body: { "token": "<token>" }
+ *
+ * Fetches the artist's SoundCloud bio and checks whether the token is present.
+ */
+export async function POST(request: NextRequest) {
+  let body: { token?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { token } = body;
+  if (!token) {
+    return NextResponse.json(
+      { error: "token is required in request body" },
+      { status: 400 }
+    );
+  }
+
+  const pending = getToken(token);
+  if (!pending) {
+    return NextResponse.json(
+      { error: "Token not found or expired. Request a new one via GET." },
+      { status: 404 }
+    );
+  }
+
+  let profile;
+  try {
+    profile = await resolveProfile(pending.username);
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Could not fetch SoundCloud profile";
+    return NextResponse.json(
+      { error: message, verified: false },
+      { status: 502 }
+    );
+  }
+
+  const bio = profile.description ?? "";
+  if (!bio.includes(token)) {
+    return NextResponse.json({
+      verified: false,
+      message: `Token not found in bio for ${profile.username}. Make sure you saved your bio after pasting the token.`,
+    });
+  }
+
+  // Success — consume the token so it can't be reused
+  consumeToken(token);
+
+  return NextResponse.json({
+    verified: true,
+    profile: {
+      username: profile.username,
+      permalink: profile.permalink,
+      avatar_url: profile.avatar_url,
+      full_name: profile.full_name,
+      city: profile.city,
+      country_code: profile.country_code,
+      followers_count: profile.followers_count,
+      track_count: profile.track_count,
+    },
+  });
+}

--- a/apps/web/src/app/claim/page.tsx
+++ b/apps/web/src/app/claim/page.tsx
@@ -18,6 +18,8 @@ export default function ClaimPage() {
   const [verificationCode, setVerificationCode] = useState("");
   const [verifyUrl, setVerifyUrl] = useState("");
   const [verifying, setVerifying] = useState(false);
+  const [soundcloudUsername, setSoundcloudUsername] = useState("");
+  const [scToken, setScToken] = useState("");
   const [releaseResult, setReleaseResult] = useState<{
     txHash?: string;
     unclaimedReleased?: string;
@@ -45,31 +47,83 @@ export default function ClaimPage() {
     setSelectedArtist(artist);
     const code = `onda-verify-${artist.id.slice(0, 8)}`;
     setVerificationCode(code);
+    setSoundcloudUsername("");
+    setScToken("");
     try {
       const details = await getArtistDetails(artist.id);
       const urls = getArtistUrls(details.relations);
-      setVerifyUrl(urls.bandcamp || urls.website || urls.soundcloud || "");
+      if (urls.soundcloud) {
+        // Extract username from SoundCloud URL (e.g. https://soundcloud.com/username)
+        const scMatch = urls.soundcloud.match(/soundcloud\.com\/([^/?#]+)/);
+        if (scMatch) {
+          setSoundcloudUsername(scMatch[1]);
+          setVerifyUrl(urls.soundcloud);
+          setStep("verify");
+          return;
+        }
+      }
+      setVerifyUrl(urls.bandcamp || urls.website || "");
     } catch {}
     setStep("verify");
+  };
+
+  /** Fetch a verification token from our SoundCloud verify endpoint. */
+  const handleSoundcloudToken = async () => {
+    if (!soundcloudUsername.trim()) return;
+    setError("");
+    try {
+      const res = await fetch(`/api/verify-soundcloud?username=${encodeURIComponent(soundcloudUsername.trim())}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Could not find that SoundCloud user.");
+        return;
+      }
+      setScToken(data.token);
+      setVerificationCode(data.token);
+    } catch {
+      setError("couldn't reach the server.");
+    }
   };
 
   const handleVerify = async (demo: boolean) => {
     setVerifying(true);
     setError("");
     try {
-      const res = await fetch("/api/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          mbid: selectedArtist!.id,
-          code: verificationCode,
-          url: demo ? undefined : verifyUrl,
-          demo,
-        }),
-      });
-      const data = await res.json();
-      if (data.verified) setStep("claim");
-      else setError(data.error || "verification didn't work.");
+      // SoundCloud verification — use the bio-token endpoint
+      if (!demo && scToken) {
+        const res = await fetch("/api/verify-soundcloud", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: scToken }),
+        });
+        const data = await res.json();
+        if (data.verified) {
+          // Also mark the MBID as verified so the claim step works
+          await fetch("/api/verify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mbid: selectedArtist!.id, code: verificationCode, demo: true }),
+          });
+          setStep("claim");
+        } else {
+          setError(data.message || data.error || "token not found in your SoundCloud bio.");
+        }
+      } else {
+        // Generic URL verification or demo mode
+        const res = await fetch("/api/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            mbid: selectedArtist!.id,
+            code: verificationCode,
+            url: demo ? undefined : verifyUrl,
+            demo,
+          }),
+        });
+        const data = await res.json();
+        if (data.verified) setStep("claim");
+        else setError(data.error || "verification didn't work.");
+      }
     } catch {
       setError("couldn't reach the server.");
     } finally {
@@ -183,9 +237,69 @@ export default function ClaimPage() {
       {/* Verify */}
       {step === "verify" && selectedArtist && (
         <div>
-          <h2 className="text-xl font-bold mb-4">verify you're {selectedArtist.name}</h2>
-          {verifyUrl ? (
+          <h2 className="text-xl font-bold mb-4">verify you&apos;re {selectedArtist.name}</h2>
+          {soundcloudUsername ? (
             <>
+              {/* SoundCloud bio-token verification */}
+              <p className="text-ink-light text-sm mb-4">
+                we&apos;ll verify through your SoundCloud bio.
+              </p>
+
+              {/* Editable username — lets the artist fix MusicBrainz typos */}
+              <div className="flex gap-3 mb-4 items-end">
+                <div className="flex-1">
+                  <label className="text-xs text-ink-faint block mb-1">soundcloud username</label>
+                  <input
+                    type="text"
+                    value={soundcloudUsername}
+                    onChange={(e) => { setSoundcloudUsername(e.target.value); setScToken(""); }}
+                    className="w-full bg-transparent border-b-2 border-ink px-1 py-2 text-sm focus:outline-none font-mono"
+                  />
+                </div>
+                <button onClick={handleSoundcloudToken} className="btn-secondary text-sm whitespace-nowrap">
+                  {scToken ? "refresh token" : "get token"}
+                </button>
+              </div>
+
+              {scToken ? (
+                <>
+                  <p className="text-ink-light text-sm mb-2">
+                    paste this token anywhere in your SoundCloud bio, then click verify:
+                  </p>
+                  <div className="ink-block p-4 mb-4 text-center font-mono text-onda select-all">
+                    {scToken}
+                  </div>
+                  <p className="text-ink-faint text-xs mb-6">
+                    your page:{" "}
+                    <a href={`https://soundcloud.com/${soundcloudUsername}`} target="_blank" rel="noopener noreferrer" className="text-onda hover:underline">
+                      soundcloud.com/{soundcloudUsername}
+                    </a>
+                    {" · "}token expires in 15 minutes
+                  </p>
+                  <div className="flex gap-3">
+                    <button onClick={() => setStep("search")} className="btn-secondary">back</button>
+                    <button onClick={() => handleVerify(false)} disabled={verifying} className="btn-primary flex-1">
+                      {verifying ? "checking bio..." : "verify"}
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <p className="text-ink-faint text-xs mb-6">
+                  click &quot;get token&quot; to start verification
+                </p>
+              )}
+
+              <button
+                onClick={() => handleVerify(true)}
+                disabled={verifying}
+                className="text-xs text-ink-faint hover:text-ink w-full text-center mt-4 py-2"
+              >
+                skip verification (demo mode)
+              </button>
+            </>
+          ) : verifyUrl ? (
+            <>
+              {/* Generic URL verification (bandcamp, website, etc.) */}
               <p className="text-ink-light text-sm mb-4">
                 add this code to your page, then click verify:
               </p>

--- a/apps/web/src/lib/soundcloud.ts
+++ b/apps/web/src/lib/soundcloud.ts
@@ -1,0 +1,164 @@
+/**
+ * SoundCloud internal API client.
+ *
+ * WARNING: This uses SoundCloud's undocumented api-v2 endpoints and
+ * client_id extraction from their JS bundles. It could break at any
+ * time if SoundCloud changes their bundle structure or API.
+ */
+
+// --- client_id cache ---
+
+let cachedClientId: string | null = null;
+let clientIdExpiresAt = 0;
+const CLIENT_ID_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Scrape a client_id from SoundCloud's JS bundles.
+ *
+ * 1. Fetch soundcloud.com homepage
+ * 2. Find all JS bundle URLs (a-v2.sndcdn.com/assets/*.js)
+ * 3. Search each bundle for a client_id string
+ */
+async function extractClientId(): Promise<string> {
+  const now = Date.now();
+  if (cachedClientId && now < clientIdExpiresAt) {
+    return cachedClientId;
+  }
+
+  const homepageRes = await fetch("https://soundcloud.com", {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; OndaVerifier/0.1)" },
+  });
+  if (!homepageRes.ok) {
+    throw new Error(`Failed to fetch SoundCloud homepage: ${homepageRes.status}`);
+  }
+
+  const html = await homepageRes.text();
+
+  // Extract JS bundle URLs — SoundCloud loads multiple chunked bundles
+  const bundleUrls = [
+    ...html.matchAll(/https:\/\/a-v2\.sndcdn\.com\/assets\/[^\s"']+\.js/g),
+  ].map((m) => m[0]);
+
+  if (bundleUrls.length === 0) {
+    throw new Error("No SoundCloud JS bundles found on homepage");
+  }
+
+  // Search bundles for client_id (usually in one of the last bundles)
+  for (const url of bundleUrls.reverse()) {
+    try {
+      const res = await fetch(url);
+      const js = await res.text();
+      const match = js.match(/client_id:"([a-zA-Z0-9]+)"/);
+      if (match) {
+        cachedClientId = match[1];
+        clientIdExpiresAt = now + CLIENT_ID_TTL_MS;
+        return cachedClientId;
+      }
+    } catch {
+      // Bundle fetch failed — try next one
+      continue;
+    }
+  }
+
+  throw new Error("Could not extract client_id from any SoundCloud bundle");
+}
+
+// --- Token store ---
+
+interface PendingToken {
+  token: string;
+  username: string;
+  createdAt: number;
+}
+
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const pendingTokens = new Map<string, PendingToken>();
+
+/** Evict expired tokens lazily. */
+function evictExpired() {
+  const now = Date.now();
+  for (const [key, entry] of pendingTokens) {
+    if (now - entry.createdAt > TOKEN_TTL_MS) {
+      pendingTokens.delete(key);
+    }
+  }
+}
+
+/** Generate a random verification token and store it. */
+export function generateToken(username: string): string {
+  evictExpired();
+
+  const hex = [...crypto.getRandomValues(new Uint8Array(8))]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const token = `verify-${hex}`;
+
+  pendingTokens.set(token, { token, username, createdAt: Date.now() });
+  return token;
+}
+
+/** Look up a pending token. Returns null if expired or not found. */
+export function getToken(token: string): PendingToken | null {
+  evictExpired();
+  return pendingTokens.get(token) ?? null;
+}
+
+/** Remove a token after successful verification. */
+export function consumeToken(token: string) {
+  pendingTokens.delete(token);
+}
+
+// --- Profile resolution ---
+
+export interface SoundCloudProfile {
+  username: string;
+  permalink: string;
+  avatar_url: string;
+  description: string | null;
+  full_name: string;
+  city: string | null;
+  country_code: string | null;
+  followers_count: number;
+  track_count: number;
+}
+
+/**
+ * Resolve a SoundCloud username to a profile via api-v2.
+ *
+ * WARNING: Undocumented endpoint — may break without notice.
+ */
+export async function resolveProfile(username: string): Promise<SoundCloudProfile> {
+  const clientId = await extractClientId();
+
+  const url = `https://api-v2.soundcloud.com/resolve?url=https://soundcloud.com/${encodeURIComponent(username)}&client_id=${clientId}`;
+
+  const res = await fetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; OndaVerifier/0.1)" },
+  });
+
+  if (res.status === 404) {
+    throw new Error(`SoundCloud user "${username}" not found`);
+  }
+  if (!res.ok) {
+    throw new Error(`SoundCloud API error: ${res.status}`);
+  }
+
+  const data = await res.json();
+
+  // The resolve endpoint returns different object types; ensure it's a user
+  if (data.kind !== "user") {
+    throw new Error(`Expected a user profile but got "${data.kind}"`);
+  }
+
+  return {
+    username: data.username,
+    permalink: data.permalink_url,
+    avatar_url: data.avatar_url,
+    description: data.description ?? null,
+    full_name: data.full_name ?? "",
+    city: data.city ?? null,
+    country_code: data.country_code ?? null,
+    followers_count: data.followers_count ?? 0,
+    track_count: data.track_count ?? 0,
+  };
+}


### PR DESCRIPTION
Extracts client_id from SoundCloud JS bundles to use their undocumented
api-v2 resolve endpoint. Artists verify ownership by pasting a generated
token in their SoundCloud bio.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>