### PR TITLE
design refresh: landing + dashboard + extension, onboarding link bridge

### DIFF
--- a/apps/extension/content/onda-bridge.js
+++ b/apps/extension/content/onda-bridge.js
@@ -48,4 +48,14 @@ window.addEventListener("message", (event) => {
     sendStatusToPage();
   }
 
+  // Web /connect page fires this on a successful join tx. Forward to the
+  // service worker so the popup updates instantly — no Hypersync / event-watcher
+  // race required.
+  if (event.data?.type === "ONDA_LINK_DETECTED") {
+    const { ownerAddress, smartAccountAddress, sessionAddress } = event.data;
+    chrome.runtime.sendMessage({
+      type: "SET_LINK",
+      data: { ownerAddress, smartAccountAddress, sessionAddress },
+    });
+  }
 });

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -14,9 +14,11 @@
     "https://*.bandcamp.com/*",
     "https://music.youtube.com/*",
     "https://app.subcult.music/*",
+    "https://musicbrainz.org/*",
     "http://localhost:3000/*",
     "https://onda-tau.vercel.app/*",
-    "https://onda.eth.pm/*"
+    "https://onda.eth.pm/*",
+    "https://getonda.org/*"
   ],
   "background": {
     "service_worker": "background/service-worker.js"
@@ -88,6 +90,15 @@
     {
       "matches": [
         "https://onda.eth.pm/*"
+      ],
+      "js": [
+        "content/onda-bridge.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://getonda.org/*"
       ],
       "js": [
         "content/onda-bridge.js"

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -3,359 +3,389 @@
 <head>
   <meta charset="UTF-8">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Fraunces:ital,wght@1,700&display=swap');
+
+    :root {
+      --onda-paper: #ECE6DB;
+      --onda-paper-2: #E3DCCD;
+      --onda-ink: #0D0D0D;
+      --onda-ink-2: #1A1A1A;
+      --onda-muted: #8A8378;
+      --onda-muted-2: #6B655B;
+      --onda-faded: #CFC6B6;
+      --onda-rust: #B8621B;
+      --onda-rust-ink: #8F4A12;
+      --onda-rust-glow: #F4A160;
+      --onda-line: rgba(13, 13, 13, 0.12);
+      --onda-line-strong: rgba(13, 13, 13, 0.24);
+    }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      width: 320px;
-      font-family: 'Inter', system-ui, sans-serif;
-      background: #f0eae0;
-      color: #151311;
-      font-size: 13px;
-      line-height: 1.4;
+    html, body {
+      width: 380px;
+      background: var(--onda-paper);
+      color: var(--onda-ink);
+      font-family: 'Inter', -apple-system, sans-serif;
+      -webkit-font-smoothing: antialiased;
     }
 
-    /* Inverted header */
-    .header {
-      background: #151311;
-      color: #f0eae0;
-      padding: 12px 16px;
+    .mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+    .serif {
+      font-family: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+      font-style: italic;
+      font-weight: 700;
+    }
+
+    /* Header — inverted ink */
+    .onda-popup__header {
       display: flex;
       justify-content: space-between;
       align-items: center;
+      padding: 16px 20px;
+      background: var(--onda-ink);
+      color: var(--onda-paper);
+      text-transform: lowercase;
     }
-    .logo {
-      font-size: 16px;
-      font-weight: 700;
-      letter-spacing: -0.3px;
+    .onda-popup__wordmark {
+      font-weight: 800;
+      font-size: 18px;
+      letter-spacing: -0.6px;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
     }
-    .header-totals {
-      text-align: right;
-    }
-    .header-balance {
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 14px;
-      font-weight: 700;
-      color: #c4813a;
-    }
-    .header-given {
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 10px;
-      color: #8a847d;
-    }
+    .onda-popup__wordmark svg { display: block; }
+    .onda-popup__balance { text-align: right; }
+    .onda-popup__balance-val { font-size: 14px; color: var(--onda-rust); font-weight: 600; }
+    .onda-popup__balance-sub { font-size: 9px; color: var(--onda-muted); margin-top: 2px; }
 
-    .body-content { padding: 14px 16px; }
-
-    /* Section label */
-    .label {
+    /* Eyebrow / live dot */
+    .onda-popup__eyebrow {
       font-size: 10px;
-      text-transform: uppercase;
+      color: var(--onda-muted-2);
       letter-spacing: 1.5px;
-      color: #8a847d;
-      margin-bottom: 8px;
-      font-weight: 500;
+      text-transform: lowercase;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .onda-live-dot {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--onda-rust);
+      box-shadow: 0 0 0 4px rgba(184, 98, 27, 0.2);
+      animation: onda-blink 2.4s ease-in-out infinite;
+    }
+    @keyframes onda-blink {
+      0%, 100% { box-shadow: 0 0 0 4px rgba(184, 98, 27, 0.2); opacity: 1; }
+      50%      { box-shadow: 0 0 0 10px rgba(184, 98, 27, 0.05); opacity: 0.65; }
     }
 
-    /* Now Playing */
-    .now-playing { padding: 0 0 10px 0; }
-    .artist-name {
-      font-size: 20px;
-      font-weight: 700;
-      color: #151311;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: 1.15;
-      letter-spacing: -0.3px;
+    /* Now playing */
+    .onda-popup__np {
+      padding: 20px 20px 24px;
+      border-bottom: 1px solid var(--onda-line);
     }
-    .track-name {
-      font-size: 13px;
-      color: #5c5650;
-      margin-top: 2px;
+    .onda-popup__np-row { display: flex; gap: 14px; margin-top: 16px; }
+    .onda-popup__art {
+      width: 72px; height: 72px; border-radius: 4px; flex-shrink: 0;
+      position: relative; overflow: hidden;
+      background: linear-gradient(135deg, #2A3A5B, #6B4A8C, #D97B4A);
     }
-    .platform-badge {
-      display: inline-block;
-      font-size: 9px;
-      padding: 2px 6px;
-      border: 1px solid #cdc5b8;
-      color: #8a847d;
-      margin-top: 6px;
-      letter-spacing: 0.5px;
-      text-transform: uppercase;
-      font-weight: 500;
+    .onda-popup__art::after {
+      content: ""; position: absolute; inset: 0;
+      background: radial-gradient(ellipse at 30% 30%, rgba(255,255,255,0.3), transparent 60%);
     }
-
-    /* Progress */
-    .progress-container { margin-top: 10px; }
-    .progress-bar {
-      height: 3px;
-      background: #cdc5b8;
-      overflow: hidden;
+    .onda-popup__np-meta { flex: 1; min-width: 0; }
+    .onda-popup__np-title {
+      font-size: 20px; font-weight: 800;
+      letter-spacing: -0.5px; line-height: 1.05;
+      text-transform: lowercase;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     }
-    .progress-fill {
-      height: 100%;
-      transition: width 0.3s ease, background-color 0.3s ease;
-      width: 0%;
-    }
-    .progress-fill.listening { background: #151311; }
-    .progress-fill.complete { background: #c4813a; }
-    .progress-text {
-      display: flex;
-      justify-content: space-between;
-      font-size: 10px;
-      color: #8a847d;
-      margin-top: 3px;
-      font-family: 'JetBrains Mono', monospace;
-    }
-
-    /* Gift result */
-    .gift-result {
-      margin-top: 8px;
-      font-size: 13px;
-      font-weight: 700;
-    }
-    .gift-result.sent { color: #c4813a; }
-    .gift-result.escrowed { color: #5c5650; }
-    .gift-result a { color: inherit; }
-
-    .gift-detail {
-      font-size: 12px;
-      color: #5c5650;
+    .onda-popup__np-artist {
+      font-size: 16px;
+      color: var(--onda-rust);
       margin-top: 4px;
+      text-transform: lowercase;
     }
-
-    /* Divider */
-    .divider {
-      border: none;
-      border-top: 1px solid #cdc5b8;
-      margin: 12px 0;
-    }
-
-    /* History */
-    .history-item {
-      display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      padding: 6px 0;
-      border-bottom: 1px solid rgba(205, 197, 184, 0.5);
-    }
-    .history-item:last-child { border-bottom: none; }
-    .history-item .h-artist {
-      font-weight: 700;
+    .onda-popup__np-empty {
       font-size: 13px;
-    }
-    .history-item .h-track {
-      color: #8a847d;
-      font-size: 11px;
-    }
-    .history-item .amount {
-      color: #c4813a;
-      font-weight: 700;
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 12px;
-      white-space: nowrap;
-    }
-    .history-item .amount a { color: inherit; text-decoration: none; }
-    .history-item .amount a:hover { text-decoration: underline; }
-
-    .empty-state {
-      padding: 16px 0;
-      color: #8a847d;
-      font-size: 12px;
+      color: var(--onda-muted);
+      margin-top: 16px;
     }
 
-    /* Wallet */
-    .wallet-section { padding: 0; }
-    .wallet-row {
-      display: flex;
-      justify-content: space-between;
+    /* Tip progress */
+    .onda-popup__tip-progress { margin-top: 16px; }
+    .onda-popup__tip-row {
+      display: flex; justify-content: space-between;
+      margin-bottom: 6px;
+      font-size: 10px; color: var(--onda-muted-2);
+      text-transform: lowercase;
+    }
+    .onda-popup__tip-bar {
+      height: 3px; background: rgba(13,13,13,0.08);
+      position: relative; overflow: hidden;
+    }
+    .onda-popup__tip-fill {
+      position: absolute; inset: 0 auto 0 0;
+      background: var(--onda-rust);
+      width: 0%;
+      transition: width 200ms linear;
+    }
+    .onda-popup__tip-fill.complete { background: var(--onda-rust); }
+    .onda-popup__tip-fill.failed { background: var(--onda-muted); }
+
+    /* Live bars */
+    .onda-popup__bars {
+      display: flex; gap: 2px; align-items: flex-end;
+      height: 16px; margin-top: 10px;
+    }
+    .onda-popup__bar {
+      flex: 1; background: var(--onda-rust);
+      transition: height 100ms;
+      min-height: 3px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .onda-popup__bar { height: 50% !important; transition: none; }
+    }
+
+    /* Connect (artist links) */
+    .onda-popup__connect-toggle {
+      margin-top: 10px;
+      background: none; border: 0; cursor: pointer;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-size: 10px; letter-spacing: 1.2px;
+      color: var(--onda-muted-2);
+      text-transform: lowercase;
+      padding: 0;
+    }
+    .onda-popup__connect-toggle:hover { color: var(--onda-rust); }
+    .onda-popup__connect-panel {
+      margin-top: 10px; padding: 10px 12px;
+      background: var(--onda-paper-2);
+      border: 1px solid var(--onda-line);
+      display: flex; flex-wrap: wrap; gap: 6px;
       align-items: center;
-      padding: 3px 0;
-      font-size: 12px;
     }
-    .wallet-label { color: #8a847d; }
-    .wallet-addr {
-      color: #5c5650;
-      cursor: pointer;
-      font-family: 'JetBrains Mono', monospace;
-      font-size: 11px;
-    }
-    .wallet-addr:hover { color: #c4813a; }
-    .wallet-val {
-      color: #151311;
-      font-family: 'JetBrains Mono', monospace;
-      font-weight: 600;
-    }
-    .wallet-val.funded { color: #c4813a; }
-    .wallet-val.empty { color: #8a847d; }
-    .wallet-btn {
-      width: 100%;
-      background: #151311;
-      color: #f0eae0;
-      border: none;
-      padding: 10px;
-      font-family: inherit;
-      font-size: 12px;
-      font-weight: 600;
-      cursor: pointer;
-      margin-top: 8px;
-    }
-    .wallet-btn:hover { background: #c4813a; }
-    .wallet-btn:disabled { opacity: 0.3; cursor: default; }
-    .wallet-btn-sm {
-      width: 100%;
-      background: transparent;
-      color: #5c5650;
-      border: 1px solid #cdc5b8;
-      padding: 6px;
-      font-family: inherit;
-      font-size: 11px;
-      cursor: pointer;
-      margin-top: 6px;
-    }
-    .wallet-btn-sm:hover { border-color: #151311; color: #151311; }
-    .wallet-fund { margin-top: 8px; }
-    .fund-label {
-      font-size: 10px;
-      color: #8a847d;
-      margin-bottom: 4px;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
-    .fund-addr {
-      font-size: 10px;
-      font-family: 'JetBrains Mono', monospace;
-      color: #5c5650;
-      word-break: break-all;
-      background: #e5ded2;
-      padding: 8px;
-      border: 1px solid #cdc5b8;
-    }
-    .wallet-ready {
+    .onda-popup__connect-pill {
       display: inline-block;
-      background: #c4813a;
-      color: #f0eae0;
-      font-size: 10px;
-      font-weight: 700;
-      padding: 3px 8px;
-      margin-top: 8px;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
+      font-size: 11px; padding: 4px 10px;
+      border: 1px solid rgba(13, 13, 13, 0.4);
+      text-decoration: none; color: var(--onda-ink);
+      text-transform: lowercase;
+      transition: color 120ms, border-color 120ms;
     }
-    .wallet-error { color: #c4813a; font-size: 12px; }
-
-    /* Onboarding / QR code */
-    .onboard-divider {
-      display: flex;
-      align-items: center;
-      margin: 10px 0;
-      font-size: 10px;
-      color: #8a847d;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
+    .onda-popup__connect-pill:hover {
+      color: var(--onda-rust); border-color: var(--onda-rust);
     }
-    .onboard-divider::before,
-    .onboard-divider::after {
-      content: "";
-      flex: 1;
-      border-top: 1px solid #cdc5b8;
+    .onda-popup__connect-status {
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-size: 10px; color: var(--onda-muted-2);
     }
-    .onboard-divider span {
-      padding: 0 8px;
-    }
-    .onboard-text {
-      font-size: 10px;
-      color: #78716c;
-      margin-bottom: 8px;
-    }
-    .qr-container {
-      display: flex;
-      justify-content: center;
-      margin: 8px 0;
-      background: #f5f0e8;
-      border: 1px solid #c4bcb0;
-      padding: 8px;
-    }
-    .qr-container canvas { display: block; }
-    .qr-link {
-      display: block;
-      text-align: center;
-      font-size: 10px;
-      color: #8a847d;
+    .onda-popup__connect-mbid {
+      margin-left: auto;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-size: 9px; letter-spacing: 1.2px;
+      color: var(--onda-muted-2);
       text-decoration: none;
-      margin-top: 6px;
+      text-transform: uppercase;
     }
-    .qr-link:hover { color: #c4813a; text-decoration: underline; }
-    .onboard-hint {
-      font-size: 9px;
-      color: #a8a29e;
-      text-align: center;
-      margin-top: 6px;
-      letter-spacing: 0.5px;
+    .onda-popup__connect-mbid:hover { color: var(--onda-rust); }
+
+    /* Gift result pill */
+    .onda-popup__gift-result {
+      display: none;
+      margin-top: 12px;
+      font-size: 11px;
+      color: var(--onda-rust);
+    }
+    .onda-popup__gift-result a { color: inherit; text-decoration: none; }
+    .onda-popup__gift-result a:hover { text-decoration: underline; }
+    .onda-popup__gift-result.failed { color: var(--onda-muted-2); }
+
+    /* Recent */
+    .onda-popup__recent { padding: 16px 20px; }
+    .onda-popup__recent-head {
+      display: flex; justify-content: space-between; align-items: baseline;
+      margin-bottom: 10px;
+    }
+    .onda-popup__link {
+      background: none; border: 0; cursor: pointer;
+      font-size: 10px; color: var(--onda-rust);
+      text-transform: lowercase;
+      text-decoration: none;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+    }
+    .onda-popup__link:hover { text-decoration: underline; }
+    .onda-popup__recent-row {
+      display: grid; grid-template-columns: 1fr auto auto;
+      gap: 12px; padding: 10px 0;
+      border-bottom: 1px solid rgba(13,13,13,0.06);
+      align-items: center;
+    }
+    .onda-popup__recent-row:last-child { border-bottom: 0; }
+    .onda-popup__recent-meta { min-width: 0; }
+    .onda-popup__recent-track {
+      font-size: 13px; font-weight: 600;
+      text-transform: lowercase;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .onda-popup__recent-artist {
+      font-size: 11px; color: var(--onda-muted-2); margin-top: 2px;
+      text-transform: lowercase;
+    }
+    .onda-popup__recent-time { font-size: 10px; color: var(--onda-muted); text-transform: lowercase; }
+    .onda-popup__recent-amt { font-size: 13px; color: var(--onda-rust); text-decoration: none; }
+    .onda-popup__recent-amt:hover { text-decoration: underline; }
+    .onda-popup__recent-empty {
+      padding: 14px 0; font-size: 12px; color: var(--onda-muted);
     }
 
     /* Footer */
-    .footer {
-      padding: 10px 16px;
-      border-top: 1px solid #cdc5b8;
+    .onda-popup__footer {
+      padding: 14px 20px;
+      border-top: 1px solid var(--onda-line);
+      display: flex; gap: 8px;
+      background: var(--onda-paper-2);
     }
-    .footer a {
-      font-size: 11px;
-      color: #8a847d;
-      text-decoration: none;
+    .onda-popup__btn {
+      font-family: inherit; font-size: 12px; font-weight: 600;
+      cursor: pointer; text-transform: lowercase;
+      transition: background 120ms;
     }
-    .footer a:hover { color: #151311; }
+    .onda-popup__btn--primary {
+      flex: 1; padding: 10px 0;
+      background: var(--onda-ink); color: var(--onda-paper); border: 0;
+    }
+    .onda-popup__btn--primary:hover { background: var(--onda-ink-2); }
+    .onda-popup__btn--primary.paused { background: var(--onda-muted-2); }
+    .onda-popup__btn--outline {
+      padding: 10px 14px; background: transparent;
+      border: 1.5px solid var(--onda-ink); color: var(--onda-ink);
+    }
+    .onda-popup__btn--outline:hover { background: rgba(13,13,13,0.05); }
+    .onda-popup__btn--outline.active {
+      background: var(--onda-ink); color: var(--onda-paper);
+    }
+
+    /* Onboarding (wallet not linked) */
+    .onda-popup__onboard {
+      padding: 20px;
+      border-bottom: 1px solid var(--onda-line);
+    }
+    .onda-popup__onboard-title {
+      font-size: 15px; font-weight: 800; letter-spacing: -0.3px;
+      margin-bottom: 4px; text-transform: lowercase;
+    }
+    .onda-popup__onboard-sub {
+      font-size: 12px; color: var(--onda-muted-2); margin-bottom: 14px;
+    }
+    .onda-popup__wallet-btn {
+      width: 100%; padding: 10px 0;
+      background: var(--onda-ink); color: var(--onda-paper);
+      border: 0; cursor: pointer; font-family: inherit;
+      font-size: 12px; font-weight: 600; text-transform: lowercase;
+      margin-bottom: 10px;
+    }
+    .onda-popup__wallet-btn:hover { background: var(--onda-ink-2); }
+    .onda-popup__onboard-divider {
+      display: flex; align-items: center; gap: 10px;
+      font-size: 9px; color: var(--onda-muted);
+      text-transform: uppercase; letter-spacing: 1.5px;
+      margin: 14px 0 12px;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+    }
+    .onda-popup__onboard-divider::before,
+    .onda-popup__onboard-divider::after {
+      content: ""; flex: 1; height: 1px; background: var(--onda-line);
+    }
+    .onda-popup__qr {
+      display: flex; justify-content: center;
+      padding: 8px 0;
+    }
+    .onda-popup__qr canvas { display: block; }
+    .onda-popup__onboard-hint {
+      font-size: 10px; color: var(--onda-muted-2);
+      text-align: center; margin-top: 10px;
+      text-transform: lowercase;
+    }
+    .onda-popup__onboard-session {
+      display: flex; justify-content: space-between;
+      font-size: 10px; color: var(--onda-muted); margin-top: 10px;
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+    }
   </style>
 </head>
 <body>
-  <div class="header">
-    <div class="logo">onda</div>
-    <div class="header-totals">
-      <div class="header-balance" id="header-balance">—</div>
-      <div class="header-given" id="total-given">$0.00 given</div>
+  <!-- Header -->
+  <header class="onda-popup__header">
+    <div class="onda-popup__wordmark">
+      <svg width="22" height="14" viewBox="0 0 28 16" aria-hidden="true">
+        <path d="M2 8 C 5 2, 9 2, 12 8 S 19 14, 22 8 L 26 8"
+              fill="none" stroke="#ECE6DB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span>onda</span>
     </div>
-  </div>
+    <div class="onda-popup__balance">
+      <div class="mono onda-popup__balance-val" id="header-balance">—</div>
+      <div class="mono onda-popup__balance-sub" id="header-given">$0.00 sent this week</div>
+    </div>
+  </header>
 
-  <div class="body-content">
-    <div id="wallet-section" class="wallet-section">
-      <!-- Filled by JS -->
+  <!-- Wallet onboarding (shown when unlinked) -->
+  <section id="wallet-section" class="onda-popup__onboard" style="display:none;"></section>
+
+  <!-- Now playing -->
+  <section id="np-section" class="onda-popup__np">
+    <div class="onda-popup__eyebrow">
+      <span class="onda-live-dot" id="live-dot"></span>
+      <span id="np-eyebrow">idle</span>
     </div>
 
-    <hr class="divider">
-
-    <div id="app">
-      <div class="label">now listening</div>
-      <div class="now-playing">
-        <div class="artist-name" id="artist-name">--</div>
-        <div class="track-name" id="track-name">play something to get started</div>
-        <div id="platform-badge" style="display: none;"></div>
-        <div class="progress-container" id="progress-container" style="display: none;">
-          <div class="progress-bar">
-            <div class="progress-fill listening" id="progress-fill"></div>
-          </div>
-          <div class="progress-text">
-            <span id="progress-time">0s</span>
-            <span id="progress-target">10s</span>
-          </div>
-        </div>
-        <div class="gift-result" id="gift-result" style="display: none;"></div>
-        <div class="gift-detail" id="gift-detail" style="display: none;"></div>
+    <div class="onda-popup__np-row" id="np-row" style="display:none;">
+      <div class="onda-popup__art" id="np-art"></div>
+      <div class="onda-popup__np-meta">
+        <div class="onda-popup__np-title" id="track-name">--</div>
+        <div class="onda-popup__np-artist" id="artist-name"></div>
+        <div class="onda-popup__bars" id="live-bars"></div>
+        <button type="button" id="np-connect-btn" class="onda-popup__connect-toggle">connect →</button>
+        <div id="np-connect-panel" class="onda-popup__connect-panel" style="display:none;"></div>
       </div>
-
-      <div id="history-section" style="display: none;">
-        <hr class="divider">
-        <div class="label">recent</div>
-        <div id="history-list"></div>
-      </div>
-
-      <div class="empty-state" id="empty-state"></div>
     </div>
-  </div>
 
-  <div class="footer">
-    <a id="dashboard-link" target="_blank">open dashboard</a>
-  </div>
+    <div class="onda-popup__np-empty" id="np-empty">
+      play something on spotify, soundcloud, bandcamp, or yt music.
+    </div>
 
-  <script src="popup.js" type="text/javascript"></script>
+    <div class="onda-popup__tip-progress" id="tip-progress" style="display:none;">
+      <div class="onda-popup__tip-row">
+        <span class="mono" id="tip-label">wave sends in</span>
+        <span class="mono" id="tip-countdown" style="color: var(--onda-rust);">—</span>
+      </div>
+      <div class="onda-popup__tip-bar">
+        <div class="onda-popup__tip-fill" id="tip-fill"></div>
+      </div>
+      <div class="onda-popup__gift-result" id="gift-result"></div>
+    </div>
+  </section>
+
+  <!-- Recent waves -->
+  <section class="onda-popup__recent">
+    <div class="onda-popup__recent-head">
+      <div class="onda-popup__eyebrow">recent waves</div>
+      <a class="onda-popup__link" id="dashboard-link" href="#" target="_blank">open dashboard →</a>
+    </div>
+    <div id="recent-list"></div>
+    <div class="onda-popup__recent-empty" id="recent-empty">no waves yet.</div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="onda-popup__footer">
+    <button class="onda-popup__btn onda-popup__btn--primary" id="btn-tip-extra">tip extra →</button>
+    <button class="onda-popup__btn onda-popup__btn--outline" id="btn-pause" title="pause auto-tips">pause</button>
+    <button class="onda-popup__btn onda-popup__btn--outline" id="btn-settings" title="settings" aria-label="settings">⚙</button>
+  </footer>
+
+  <script src="popup.js"></script>
 </body>
 </html>

--- a/apps/extension/src/popup.js
+++ b/apps/extension/src/popup.js
@@ -1,134 +1,300 @@
-// onda popup — receipt-style wallet + scrobble state + history
+// onda popup — now-playing + recent waves + wallet onboarding, new design
 import QRCode from "qrcode";
 
-document.getElementById("dashboard-link").href =
-  `${process.env.PATRON_WEB_URL}/dashboard`;
+const WEB_URL = process.env.PATRON_WEB_URL;
+
+// Dashboard link
+const dashLink = document.getElementById("dashboard-link");
+if (dashLink) dashLink.href = `${WEB_URL}/dashboard`;
 
 // Keep the service worker alive while the popup is open (MV3 requirement).
 // Also receives LINKED messages when a Joined event is detected on-chain.
 const swPort = chrome.runtime.connect({ name: "popup" });
 swPort.onMessage.addListener((msg) => {
   if (msg.type === "LINKED") {
-    currentlyLinked = true;
-    renderLinked(msg);
+    // Force renderWallet's transition block to run (it only runs when
+    // currentlyLinked !== true, so don't pre-set it to true here).
+    renderWallet();
   }
 });
 
-const platformNames = {
-  spotify: "Spotify",
-  soundcloud: "SoundCloud",
-  bandcamp: "Bandcamp",
-  "youtube-music": "YouTube Music",
+const PLATFORM_NAMES = {
+  spotify: "spotify",
+  soundcloud: "soundcloud",
+  bandcamp: "bandcamp",
+  "youtube-music": "yt music",
+  subcult: "subcult",
 };
 
-// --- Account / Wallet UI ---
+function shortAddr(addr) {
+  if (!addr) return "—";
+  return addr.slice(0, 6) + "…" + addr.slice(-4);
+}
+
+function platformLabel(platform) {
+  return PLATFORM_NAMES[platform] || platform || "somewhere";
+}
+
+function timeAgo(ts) {
+  const s = Math.floor((Date.now() - ts) / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+// ── Live bars (animated when listening) ─────────────────────────
+
+const BARS_EL = document.getElementById("live-bars");
+const BAR_COUNT = 28;
+for (let i = 0; i < BAR_COUNT; i++) {
+  const b = document.createElement("div");
+  b.className = "onda-popup__bar";
+  b.style.height = "3px";
+  BARS_EL.appendChild(b);
+}
+const BAR_NODES = Array.from(BARS_EL.children);
+let barTick = 0;
+let barsActive = false;
+
+function animateBars() {
+  if (!barsActive) return;
+  barTick += 1;
+  for (let i = 0; i < BAR_NODES.length; i++) {
+    const h = 4 + Math.abs(Math.sin((barTick + i * 0.7) * 0.3)) * 12;
+    BAR_NODES[i].style.height = `${Math.max(3, h)}px`;
+  }
+  requestAnimationFrame(animateBars);
+}
+
+function setBars(active) {
+  if (active && !barsActive) {
+    barsActive = true;
+    requestAnimationFrame(animateBars);
+  } else if (!active && barsActive) {
+    barsActive = false;
+    for (const n of BAR_NODES) n.style.height = "3px";
+  }
+}
+
+// ── Account / Wallet UI ─────────────────────────────────────────
 
 let currentlyLinked = null; // track to avoid re-rendering QR on every tick
 
 function renderWallet() {
   chrome.runtime.sendMessage({ type: "GET_ACCOUNT_STATUS" }, (status) => {
-    if (chrome.runtime.lastError || !status) {
-      document.getElementById("wallet-section").innerHTML =
-        `<div class="wallet-error">Extension loading...</div>`;
-      return;
-    }
+    if (chrome.runtime.lastError || !status) return;
 
     if (!status.isLinked) {
-      // Only re-render QR if we weren't already showing it
       if (currentlyLinked !== false) {
         currentlyLinked = false;
         renderOnboarding(status.sessionAddress);
       }
     } else {
-      if (currentlyLinked !== true) {
-        currentlyLinked = true;
-        renderLinked(status);
-      }
+      // Enforce visible state every tick — idempotent and guards against
+      // any path where currentlyLinked gets out of sync with the DOM.
+      document.getElementById("wallet-section").style.display = "none";
+      document.getElementById("np-section").style.display = "block";
+      currentlyLinked = true;
+      const bal = document.getElementById("header-balance");
+      if (bal) bal.textContent = status.usdcBalance != null ? `$${status.usdcBalance}` : "—";
     }
   });
 }
 
 function renderOnboarding(sessionAddress) {
   const section = document.getElementById("wallet-section");
+  const np = document.getElementById("np-section");
+  section.style.display = "block";
+  np.style.display = "none";
+
   section.innerHTML = `
-    <div class="label">Connect Wallet</div>
-    <button class="wallet-btn" id="connect-browser-btn">Connect Browser Wallet</button>
-    <div class="onboard-divider"><span>or scan QR code</span></div>
-    <div id="qr-container" class="qr-container"></div>
-    <div class="wallet-row" style="margin-top:6px">
-      <span class="wallet-label">Session</span>
-      <span class="wallet-addr">${shortAddr(sessionAddress)}</span>
+    <div class="onda-popup__onboard-title">connect a wallet</div>
+    <div class="onda-popup__onboard-sub">sign in to start sending waves to artists.</div>
+    <button class="onda-popup__wallet-btn" id="connect-browser-btn">connect browser wallet</button>
+    <div class="onda-popup__onboard-divider">or scan qr</div>
+    <div id="qr-container" class="onda-popup__qr"></div>
+    <div class="onda-popup__onboard-session">
+      <span>session</span>
+      <span>${shortAddr(sessionAddress)}</span>
     </div>
-    <div class="onboard-hint">Keep this open — it will update once detected</div>
+    <div class="onda-popup__onboard-hint">keep this open — it updates when detected</div>
   `;
 
-  // Fetch the join URI, wire up the button, and render QR
   chrome.runtime.sendMessage({ type: "GET_JOIN_URI" }, async (uri) => {
     if (!uri || uri.error) return;
-
-    // Browser wallet button opens the connect page in a new tab
     const btn = document.getElementById("connect-browser-btn");
-    if (btn) {
-      btn.addEventListener("click", () => {
-        chrome.tabs.create({ url: uri });
-      });
-    }
+    if (btn) btn.addEventListener("click", () => chrome.tabs.create({ url: uri }));
 
     const container = document.getElementById("qr-container");
     if (!container) return;
-
     const canvas = document.createElement("canvas");
     try {
       await QRCode.toCanvas(canvas, uri, {
-        width: 200,
+        width: 180,
         margin: 2,
-        color: { dark: "#1c1917", light: "#f5f0e8" },
+        color: { dark: "#0D0D0D", light: "#ECE6DB" },
       });
       container.appendChild(canvas);
-    } catch (err) {
+    } catch {
       container.textContent = uri;
     }
   });
 }
 
-function renderLinked(status) {
-  const section = document.getElementById("wallet-section");
-  const balanceDisplay = status.usdcBalance != null ? `$${status.usdcBalance}` : "…";
+// ── Artist connect (MusicBrainz platform links) ─────────────────
 
-  // Update header balance
-  const headerBalance = document.getElementById("header-balance");
-  if (headerBalance) {
-    headerBalance.textContent = status.usdcBalance != null ? `$${status.usdcBalance}` : "—";
+const PLATFORM_LABEL_MAP = {
+  spotify: "spotify",
+  bandcamp: "bandcamp",
+  soundcloud: "soundcloud",
+  youtube: "yt music",
+  website: "website",
+};
+
+let connectState = {
+  artist: null, // lowercased artist name currently in the panel
+  open: false,
+  status: "idle", // idle | loading | ready | empty | error
+  data: null, // { mbid, urls }
+};
+
+// Direct MusicBrainz lookup — same shape the /lib/musicbrainz helpers use
+// on the dashboard, inlined so the extension doesn't depend on our web API.
+const MB_BASE = "https://musicbrainz.org/ws/2";
+
+function mbUrlsFromRelations(relations) {
+  const urls = {};
+  for (const rel of relations || []) {
+    const resource = rel?.url?.resource || "";
+    if (resource.includes("bandcamp.com")) urls.bandcamp = resource;
+    else if (resource.includes("soundcloud.com")) urls.soundcloud = resource;
+    else if (resource.includes("spotify.com")) urls.spotify = resource;
+    else if (resource.includes("youtube.com") || resource.includes("youtu.be"))
+      urls.youtube = resource;
+    else if (rel?.type === "official homepage") urls.website = resource;
+  }
+  return urls;
+}
+
+async function fetchArtistLinks(name) {
+  const q = encodeURIComponent(`artist:"${name}"`);
+  const searchRes = await fetch(`${MB_BASE}/artist/?query=${q}&fmt=json&limit=1`);
+  if (!searchRes.ok) throw new Error(`MB search ${searchRes.status}`);
+  const searchJson = await searchRes.json();
+  const top = (searchJson.artists || [])[0];
+  if (!top) return { found: false };
+
+  const detailsRes = await fetch(`${MB_BASE}/artist/${top.id}?inc=url-rels&fmt=json`);
+  if (!detailsRes.ok) throw new Error(`MB details ${detailsRes.status}`);
+  const details = await detailsRes.json();
+  const urls = mbUrlsFromRelations(details.relations);
+  return { found: true, mbid: top.id, urls };
+}
+
+function renderConnectPanel() {
+  const panel = document.getElementById("np-connect-panel");
+  const toggle = document.getElementById("np-connect-btn");
+  if (!panel || !toggle) return;
+
+  if (!connectState.open) {
+    panel.style.display = "none";
+    toggle.textContent = "connect →";
+    return;
   }
 
-  section.innerHTML = `
-    <div class="label">Account</div>
-    <div class="wallet-row">
-      <span class="wallet-label">Owner</span>
-      <span class="wallet-addr" title="${status.ownerAddress}">${shortAddr(status.ownerAddress)}</span>
-    </div>
-    <div class="wallet-row">
-      <span class="wallet-label">Smart Account</span>
-      <span class="wallet-addr" title="${status.smartAccountAddress}">${shortAddr(status.smartAccountAddress)}</span>
-    </div>
-    <div class="wallet-row">
-      <span class="wallet-label">Session</span>
-      <span class="wallet-addr" title="${status.sessionAddress}">${shortAddr(status.sessionAddress)}</span>
-    </div>
-    <div class="wallet-row">
-      <span class="wallet-label">Balance</span>
-      <span class="wallet-addr">${balanceDisplay} USDC</span>
-    </div>
-    <div class="wallet-ready">Ready to auto-tip</div>
-  `;
+  toggle.textContent = "hide ↑";
+  panel.style.display = "flex";
+
+  if (connectState.status === "loading") {
+    panel.innerHTML = `<span class="onda-popup__connect-status">looking up…</span>`;
+    return;
+  }
+  if (connectState.status === "error") {
+    panel.innerHTML = `<span class="onda-popup__connect-status">couldn't reach musicbrainz</span>`;
+    return;
+  }
+  if (connectState.status === "empty") {
+    panel.innerHTML = `<span class="onda-popup__connect-status">no public links on musicbrainz</span>`;
+    return;
+  }
+  if (connectState.status === "ready" && connectState.data) {
+    const { urls = {}, mbid } = connectState.data;
+    const pills = Object.entries(urls).map(([key, href]) => {
+      const label = PLATFORM_LABEL_MAP[key] || key;
+      return `<a class="onda-popup__connect-pill" href="${href}" target="_blank" rel="noopener">${label}</a>`;
+    });
+    const mbidLink = mbid
+      ? `<a class="onda-popup__connect-mbid" href="https://musicbrainz.org/artist/${mbid}" target="_blank" rel="noopener">MB ↗</a>`
+      : "";
+    panel.innerHTML = pills.join("") + mbidLink;
+  }
 }
 
-function shortAddr(addr) {
-  if (!addr) return "—";
-  return addr.slice(0, 6) + "..." + addr.slice(-4);
+async function openConnect(artistName) {
+  connectState.artist = artistName.toLowerCase();
+  connectState.open = true;
+
+  // Already loaded for this artist? Just show.
+  if (connectState.data) {
+    renderConnectPanel();
+    return;
+  }
+
+  connectState.status = "loading";
+  renderConnectPanel();
+  try {
+    const result = await fetchArtistLinks(artistName);
+    if (!result.found || !result.urls || Object.keys(result.urls).length === 0) {
+      connectState.status = "empty";
+      connectState.data = { mbid: result.mbid, urls: {} };
+    } else {
+      connectState.status = "ready";
+      connectState.data = { mbid: result.mbid, urls: result.urls };
+    }
+  } catch {
+    connectState.status = "error";
+  }
+  renderConnectPanel();
 }
 
-// --- Scrobble UI ---
+function closeConnect() {
+  connectState.open = false;
+  renderConnectPanel();
+}
+
+function resetConnect() {
+  connectState = { artist: null, open: false, status: "idle", data: null };
+  renderConnectPanel();
+}
+
+function syncConnectForArtist(currentArtistName) {
+  if (!currentArtistName) {
+    if (connectState.artist) resetConnect();
+    return;
+  }
+  const key = currentArtistName.toLowerCase();
+  if (connectState.artist && connectState.artist !== key) {
+    // artist changed — drop any cached data and close
+    resetConnect();
+  }
+}
+
+// Wire toggle button
+const connectBtn = document.getElementById("np-connect-btn");
+if (connectBtn) {
+  connectBtn.addEventListener("click", () => {
+    const artistNameEl = document.getElementById("artist-name");
+    const name = artistNameEl ? artistNameEl.textContent.trim() : "";
+    if (!name) return;
+    if (connectState.open) closeConnect();
+    else openConnect(name);
+  });
+}
+
+// ── Scrobble / now-playing UI ───────────────────────────────────
 
 function update() {
   chrome.runtime.sendMessage({ type: "GET_STATUS" }, (response) => {
@@ -137,110 +303,172 @@ function update() {
     const { scrobble, totalGiven, recentGifts } = response;
     const state = scrobble?.status || "idle";
 
-    document.getElementById("total-given").textContent = `$${totalGiven} given`;
+    // Header "sent this week"
+    const given = document.getElementById("header-given");
+    if (given) given.textContent = `$${totalGiven || "0.00"} sent this week`;
+
+    const eyebrow = document.getElementById("np-eyebrow");
+    const npRow = document.getElementById("np-row");
+    const npEmpty = document.getElementById("np-empty");
+    const trackEl = document.getElementById("track-name");
+    const artistEl = document.getElementById("artist-name");
+    const tipProgress = document.getElementById("tip-progress");
+    const tipFill = document.getElementById("tip-fill");
+    const tipLabel = document.getElementById("tip-label");
+    const tipCountdown = document.getElementById("tip-countdown");
+    const giftResult = document.getElementById("gift-result");
+    const liveDot = document.getElementById("live-dot");
+
+    // Default state reset
+    tipFill.classList.remove("complete", "failed");
+    giftResult.classList.remove("failed");
+    giftResult.style.display = "none";
 
     if (scrobble?.artist) {
-      document.getElementById("track-name").textContent = scrobble.track || "--";
-      document.getElementById("artist-name").textContent = scrobble.artist;
-      document.getElementById("empty-state").style.display = "none";
-
-      const badge = document.getElementById("platform-badge");
-      if (scrobble.platform) {
-        badge.style.display = "inline-block";
-        badge.textContent = platformNames[scrobble.platform] || scrobble.platform;
-        badge.className = "platform-badge";
-      }
+      npRow.style.display = "flex";
+      npEmpty.style.display = "none";
+      trackEl.textContent = scrobble.track || "--";
+      artistEl.textContent = scrobble.artist;
+      eyebrow.textContent = `listening · ${platformLabel(scrobble.platform)}`;
+      syncConnectForArtist(scrobble.artist);
+    } else {
+      npRow.style.display = "none";
+      npEmpty.style.display = "block";
+      eyebrow.textContent = "idle";
+      syncConnectForArtist(null);
+      setBars(false);
+      tipProgress.style.display = "none";
+      liveDot.style.animationPlayState = "paused";
+      renderRecent(recentGifts);
+      return;
     }
-
-    const progressContainer = document.getElementById("progress-container");
-    const progressFill = document.getElementById("progress-fill");
-    const giftResult = document.getElementById("gift-result");
-    const giftDetail = document.getElementById("gift-detail");
 
     if (state === "listening") {
-      progressContainer.style.display = "block";
-      giftResult.style.display = "none";
-      giftDetail.style.display = "none";
-      progressFill.className = "progress-fill listening";
-      progressFill.style.width = `${scrobble.percent || 0}%`;
-      const elapsed = Math.round((scrobble.percent / 100) * (scrobble.threshold / 1000));
-      document.getElementById("progress-time").textContent = `${elapsed}s`;
-      document.getElementById("progress-target").textContent = `${scrobble.threshold / 1000}s`;
+      setBars(true);
+      tipProgress.style.display = "block";
+      tipFill.style.width = `${scrobble.percent || 0}%`;
+      const thresholdS = Math.round((scrobble.threshold || 0) / 1000);
+      const elapsedS = Math.round(((scrobble.percent || 0) / 100) * thresholdS);
+      const remaining = Math.max(0, thresholdS - elapsedS);
+      tipLabel.textContent = "wave sends in";
+      tipCountdown.textContent = `${remaining}s`;
+      liveDot.style.animationPlayState = "running";
     } else if (state === "gifted") {
-      progressContainer.style.display = "block";
-      progressFill.className = "progress-fill complete";
-      progressFill.style.width = "100%";
-      document.getElementById("progress-time").textContent = "";
+      setBars(false);
+      tipProgress.style.display = "block";
+      tipFill.classList.add("complete");
+      tipFill.style.width = "100%";
+      tipLabel.textContent = "wave sent";
+      tipCountdown.textContent = `$${(scrobble.amount || 0.01).toFixed(2)}`;
       giftResult.style.display = "block";
-      giftResult.className = "gift-result sent";
       if (scrobble.txHash) {
-        giftResult.innerHTML = `<a href="https://testnet.arcscan.app/tx/${scrobble.txHash}" target="_blank">sent $0.01 to ${scrobble.artist || "artist"}</a>`;
+        giftResult.innerHTML = `<a href="https://testnet.arcscan.app/tx/${scrobble.txHash}" target="_blank">sent to ${scrobble.artist}</a>`;
       } else {
-        giftResult.textContent = `sent $0.01 to ${scrobble.artist || "artist"}`;
+        giftResult.textContent = `sent to ${scrobble.artist}`;
       }
-      giftDetail.style.display = "none";
-      renderWallet();
+      renderWallet(); // refresh balance
     } else if (state === "scrobbled") {
-      progressContainer.style.display = "block";
-      progressFill.className = "progress-fill complete";
-      progressFill.style.width = "100%";
-      document.getElementById("progress-time").textContent = "sending...";
-      giftResult.style.display = "none";
-      giftDetail.style.display = "none";
+      setBars(false);
+      tipProgress.style.display = "block";
+      tipFill.classList.add("complete");
+      tipFill.style.width = "100%";
+      tipLabel.textContent = "sending…";
+      tipCountdown.textContent = "";
     } else if (state === "gift_failed") {
-      progressContainer.style.display = "block";
-      progressFill.className = "progress-fill";
-      progressFill.style.width = "100%";
-      progressFill.style.background = "#c4813a";
+      setBars(false);
+      tipProgress.style.display = "block";
+      tipFill.classList.add("failed");
+      tipFill.style.width = "100%";
+      tipLabel.textContent = "couldn't send";
+      tipCountdown.textContent = "";
       giftResult.style.display = "block";
-      giftResult.className = "gift-result";
-      giftResult.textContent = scrobble.giftError || "couldn't send this one";
-      giftDetail.style.display = "none";
+      giftResult.classList.add("failed");
+      giftResult.textContent = scrobble.giftError || "try again next track";
     } else if (state === "paused") {
-      progressContainer.style.display = "block";
-      giftResult.style.display = "none";
-      giftDetail.style.display = "none";
+      setBars(false);
+      tipProgress.style.display = "block";
+      tipFill.style.width = "0%";
+      tipLabel.textContent = "paused";
+      tipCountdown.textContent = "";
+      liveDot.style.animationPlayState = "paused";
     } else if (state === "skipped") {
-      progressContainer.style.display = "block";
-      progressFill.style.width = "0%";
-      giftResult.style.display = "block";
-      giftResult.className = "gift-result escrowed";
-      giftResult.textContent = "skipped";
-      giftDetail.style.display = "none";
+      setBars(false);
+      tipProgress.style.display = "block";
+      tipFill.style.width = "0%";
+      tipLabel.textContent = "skipped";
+      tipCountdown.textContent = "";
     } else {
-      progressContainer.style.display = "none";
-      giftResult.style.display = "none";
-      giftDetail.style.display = "none";
+      setBars(false);
+      tipProgress.style.display = "none";
     }
 
-    // History
-    const historySection = document.getElementById("history-section");
-    const historyList = document.getElementById("history-list");
-    if (recentGifts && recentGifts.length > 0) {
-      historySection.style.display = "block";
-      historyList.innerHTML = recentGifts
-        .slice(0, 5)
-        .map(
-          (gift) => `
-        <div class="history-item">
-          <div>
-            <div class="h-artist">${gift.artist}</div>
-            <div class="h-track">${gift.track} · ${platformNames[gift.platform] || gift.platform}</div>
-          </div>
-          <div class="amount">
-            ${gift.txHash
-              ? `<a href="https://testnet.arcscan.app/tx/${gift.txHash}" target="_blank">$${gift.amount.toFixed(2)}</a>`
-              : "$" + gift.amount.toFixed(2)}
-          </div>
-        </div>
-      `
-        )
-        .join("");
-    }
+    renderRecent(recentGifts);
   });
 }
 
-// Poll account status every second (catches the moment join tx is detected)
+function renderRecent(recentGifts) {
+  const list = document.getElementById("recent-list");
+  const empty = document.getElementById("recent-empty");
+  if (!recentGifts || recentGifts.length === 0) {
+    list.innerHTML = "";
+    empty.style.display = "block";
+    return;
+  }
+  empty.style.display = "none";
+  list.innerHTML = recentGifts
+    .slice(0, 5)
+    .map((g) => {
+      const amtEl = g.txHash
+        ? `<a class="mono onda-popup__recent-amt" href="https://testnet.arcscan.app/tx/${g.txHash}" target="_blank">+$${(g.amount || 0.01).toFixed(2)}</a>`
+        : `<span class="mono onda-popup__recent-amt">+$${(g.amount || 0.01).toFixed(2)}</span>`;
+      return `
+        <div class="onda-popup__recent-row">
+          <div class="onda-popup__recent-meta">
+            <div class="onda-popup__recent-track">${escapeHtml(g.track || "")}</div>
+            <div class="onda-popup__recent-artist">${escapeHtml(g.artist || "")} · ${platformLabel(g.platform)}</div>
+          </div>
+          <span class="mono onda-popup__recent-time">${timeAgo(g.timestamp)}</span>
+          ${amtEl}
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ── Footer buttons ──────────────────────────────────────────────
+
+document.getElementById("btn-tip-extra").addEventListener("click", () => {
+  chrome.tabs.create({ url: `${WEB_URL}/dashboard` });
+});
+
+let paused = false;
+const btnPause = document.getElementById("btn-pause");
+btnPause.addEventListener("click", () => {
+  // Best-effort: service worker may or may not handle this yet.
+  paused = !paused;
+  btnPause.classList.toggle("active", paused);
+  btnPause.textContent = paused ? "resume" : "pause";
+  chrome.runtime.sendMessage({ type: "PAUSE_TOGGLE", paused });
+});
+
+document.getElementById("btn-settings").addEventListener("click", () => {
+  if (chrome.runtime.openOptionsPage) {
+    chrome.runtime.openOptionsPage();
+  } else {
+    chrome.tabs.create({ url: `${WEB_URL}/dashboard` });
+  }
+});
+
+// Poll account status + scrobble state every second.
 setInterval(renderWallet, 1000);
 setInterval(update, 1000);
 update();

--- a/apps/extension/src/service-worker.js
+++ b/apps/extension/src/service-worker.js
@@ -22,8 +22,11 @@ initSession().then(({ sessionAddress, isNew }) => {
 
 // Keep the service worker alive while the popup holds a port open.
 // While connected, watch for a Joined event and notify the popup when found.
+let activePopupPort = null;
+
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== "popup") return;
+  activePopupPort = port;
 
   let unwatch = null;
 
@@ -38,6 +41,7 @@ chrome.runtime.onConnect.addListener((port) => {
 
   port.onDisconnect.addListener(() => {
     if (unwatch) unwatch();
+    if (activePopupPort === port) activePopupPort = null;
   });
 });
 
@@ -121,6 +125,30 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         .then(sendResponse)
         .catch((err) => sendResponse({ error: err.message }));
       return true;
+
+    case "SET_LINK": {
+      // Push from the web /connect page via the content-script bridge.
+      // Only accept if the session key matches ours — prevents any tab
+      // from flipping our link state.
+      const { ownerAddress, smartAccountAddress, sessionAddress } = data || {};
+      if (!ownerAddress || !smartAccountAddress || !sessionAddress) {
+        sendResponse({ ok: false, reason: "missing fields" });
+        return false;
+      }
+      chrome.storage.local.get(["sessionAddress"]).then(({ sessionAddress: stored }) => {
+        if (!stored || stored.toLowerCase() !== sessionAddress.toLowerCase()) {
+          sendResponse({ ok: false, reason: "session mismatch" });
+          return;
+        }
+        chrome.storage.local.set({ ownerAddress, smartAccountAddress }).then(() => {
+          if (activePopupPort) {
+            activePopupPort.postMessage({ type: "LINKED", ownerAddress, smartAccountAddress });
+          }
+          sendResponse({ ok: true });
+        });
+      });
+      return true;
+    }
   }
 
   chrome.storage.local.set({ scrobbleState });

--- a/apps/web/src/app/connect/page.tsx
+++ b/apps/web/src/app/connect/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAccount, useWriteContract, useWaitForTransactionReceipt, useReadContract } from "wagmi";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
@@ -99,6 +99,24 @@ function ConnectInner() {
   });
 
   const sessionValid = sessionKey && isAddress(sessionKey);
+
+  // Push link details to the onda extension so the popup updates immediately,
+  // without relying on Hypersync backfill or the extension's own event watcher
+  // (which gets torn down when Chrome closes the popup during this flow).
+  useEffect(() => {
+    if (!isSuccess) return;
+    if (!address || !sessionKey) return;
+    if (!smartAccount || smartAccount === "0x0000000000000000000000000000000000000000") return;
+    window.postMessage(
+      {
+        type: "ONDA_LINK_DETECTED",
+        ownerAddress: address,
+        smartAccountAddress: smartAccount,
+        sessionAddress: sessionKey,
+      },
+      "*"
+    );
+  }, [isSuccess, address, smartAccount, sessionKey]);
 
   function handleJoin() {
     if (!sessionValid) return;

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,42 +1,62 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useAccount, useReadContract } from "wagmi";
 import type { Address } from "viem";
 import { USDC_ADDRESS, ERC20_ABI, formatUSDC } from "@/lib/contracts";
-import { FundExtension } from "@/components/FundExtension";
 import { GiftFeed } from "@/components/GiftFeed";
-import { WorldIDVerify } from "@/components/WorldIDVerify";
 import { ListeningActivity } from "@/components/ListeningActivity";
 import { TopArtists } from "@/components/TopArtists";
 import { PlatformBreakdown } from "@/components/PlatformBreakdown";
-import { ListeningStreak } from "@/components/ListeningStreak";
+import { Sparkline } from "@/components/dashboard/Sparkline";
+import { TopUpPanel } from "@/components/dashboard/TopUpPanel";
+
+interface GiftRecord {
+  artist: string;
+  track: string;
+  amount: number;
+  platform: string;
+  timestamp: number;
+  txHash: string | null;
+}
+
+function getISOWeek(d: Date): number {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+function dayKey(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
 
 export default function DashboardPage() {
   const { isConnected } = useAccount();
-  const [isHumanVerified, setIsHumanVerified] = useState(false);
   const [extWalletAddr, setExtWalletAddr] = useState<Address | undefined>();
+  const [gifts, setGifts] = useState<GiftRecord[]>([]);
   const [uniqueArtists, setUniqueArtists] = useState(0);
-  const [giftsThisWeek, setGiftsThisWeek] = useState(0);
-  const [showSetup, setShowSetup] = useState(false);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (event.source !== window) return;
       if (event.data?.type === "ONDA_STATUS" && event.data.status) {
         setUniqueArtists(event.data.status.uniqueArtists || 0);
-
-        const gifts = event.data.status.recentGifts || [];
-        const weekAgo = Date.now() - 7 * 86400000;
-        setGiftsThisWeek(gifts.filter((g: { timestamp: number }) => g.timestamp >= weekAgo).length);
+        setGifts(event.data.status.recentGifts || []);
       }
     };
     window.addEventListener("message", handler);
     window.postMessage({ type: "ONDA_REQUEST_STATUS" }, "*");
-    return () => window.removeEventListener("message", handler);
+    const interval = setInterval(() => {
+      window.postMessage({ type: "ONDA_REQUEST_STATUS" }, "*");
+    }, 5000);
+    return () => {
+      window.removeEventListener("message", handler);
+      clearInterval(interval);
+    };
   }, []);
 
-  // extWalletAddr is the smart account address posted by the extension
   const { data: extBalance } = useReadContract({
     address: USDC_ADDRESS,
     abi: ERC20_ABI,
@@ -44,125 +64,178 @@ export default function DashboardPage() {
     args: extWalletAddr ? [extWalletAddr] : undefined,
     query: { enabled: !!extWalletAddr, refetchInterval: 5000 },
   });
-
   const balance = (extBalance as bigint) || 0n;
+  const balanceUSD = balance ? formatUSDC(balance) : "0.00";
+  const [dollars, cents = "00"] = balanceUSD.split(".");
 
   const onExtWalletDetected = useCallback((addr: string) => {
     setExtWalletAddr(addr as Address);
   }, []);
 
-  const setupComplete =
-    isConnected && isHumanVerified && !!extWalletAddr && balance > 0n && uniqueArtists > 0;
+  const giftsThisWeek = useMemo(() => {
+    const weekAgo = Date.now() - 7 * 86400000;
+    return gifts.filter((g) => g.timestamp >= weekAgo).length;
+  }, [gifts]);
+
+  const giftsLastWeek = useMemo(() => {
+    const twoWeekAgo = Date.now() - 14 * 86400000;
+    const oneWeekAgo = Date.now() - 7 * 86400000;
+    return gifts.filter((g) => g.timestamp >= twoWeekAgo && g.timestamp < oneWeekAgo).length;
+  }, [gifts]);
+
+  const weekDelta =
+    giftsLastWeek > 0
+      ? Math.round(((giftsThisWeek - giftsLastWeek) / giftsLastWeek) * 100)
+      : null;
+
+  const artistsThisWeek = useMemo(() => {
+    const weekAgo = Date.now() - 7 * 86400000;
+    return new Set(gifts.filter((g) => g.timestamp >= weekAgo).map((g) => g.artist)).size;
+  }, [gifts]);
+
+  const dayStreak = useMemo(() => {
+    if (gifts.length === 0) return 0;
+    const days = new Set(gifts.map((g) => dayKey(g.timestamp)));
+    let streak = 0;
+    const cursor = new Date();
+    while (true) {
+      if (days.has(dayKey(cursor.getTime()))) {
+        streak += 1;
+        cursor.setDate(cursor.getDate() - 1);
+      } else if (streak === 0) {
+        cursor.setDate(cursor.getDate() - 1);
+        if (!days.has(dayKey(cursor.getTime()))) break;
+      } else break;
+    }
+    return streak;
+  }, [gifts]);
+
+  const sparkValues = useMemo(() => {
+    const out: number[] = [];
+    const now = new Date();
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const start = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+      const end = start + 86400000;
+      out.push(gifts.filter((g) => g.timestamp >= start && g.timestamp < end).length);
+    }
+    return out;
+  }, [gifts]);
+
+  const week = useMemo(() => getISOWeek(new Date()), []);
+  const remainingPlays = balance ? Number(balance / 10000n) * 100 : 0;
 
   if (!isConnected) {
     return (
-      <div className="max-w-4xl mx-auto px-5 sm:px-8 py-20">
-        <h1 className="text-4xl font-bold mb-3">dashboard</h1>
+      <div className="max-w-6xl mx-auto px-5 sm:px-8 py-20">
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint mb-3">
+          your wallet
+        </div>
+        <h1 className="text-4xl font-bold mb-3">sign in to start.</h1>
         <p className="text-ink-light text-sm">
-          sign in to start supporting artists.
+          connect a wallet to see your balance, supported artists, and recent waves.
         </p>
       </div>
     );
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-5 sm:px-8 py-10">
-      {/* Hero — your total */}
-      <div className="mb-12">
-        <div className="text-xs uppercase tracking-widest text-ink-faint mb-2">Balance</div>
-        <div className="font-mono text-6xl sm:text-7xl font-bold tracking-tight text-onda leading-none">
-          ${balance ? formatUSDC(balance) : "0.00"}
+    <div className="max-w-6xl mx-auto px-5 sm:px-8 py-10">
+      {/* Wallet hero */}
+      <section className="mb-10">
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint mb-3">
+          your wallet · week {week}
         </div>
-        {giftsThisWeek > 0 && (
-          <div className="text-sm text-ink-faint mt-2">
-            {giftsThisWeek} gift{giftsThisWeek !== 1 ? "s" : ""} this week
+        <div className="grid gap-6 items-end" style={{ gridTemplateColumns: "1.4fr 1fr" }}>
+          <div>
+            <div className="flex items-baseline">
+              <span className="font-mono text-5xl sm:text-7xl font-bold text-ink-faint">$</span>
+              <span className="font-mono text-6xl sm:text-8xl font-bold tracking-tight leading-none">
+                {dollars}
+              </span>
+              <span className="font-mono text-6xl sm:text-8xl font-bold tracking-tight leading-none text-onda">
+                .{cents}
+              </span>
+            </div>
+            <p className="text-ink-light max-w-md mt-4 leading-snug">
+              balance — enough for{" "}
+              <span className="onda-serif-italic">
+                {remainingPlays.toLocaleString()} more plays
+              </span>{" "}
+              before you&apos;ll want to top up.
+            </p>
           </div>
-        )}
-      </div>
+          <div className="hidden sm:block">
+            <Sparkline values={sparkValues} width={420} height={110} />
+          </div>
+        </div>
+      </section>
 
-      {/* Stats */}
-      <div className="grid sm:grid-cols-3 gap-6 mb-12">
-        <div className="border-l-2 border-ink pl-4">
-          <div className="font-mono text-2xl font-bold">${balance ? formatUSDC(balance) : "0.00"}</div>
-          <div className="text-sm text-ink-light">balance remaining</div>
-        </div>
-        <div className="border-l-2 border-ink pl-4">
-          <div className="font-mono text-2xl font-bold">{uniqueArtists}</div>
-          <div className="text-sm text-ink-light">artists supported</div>
-        </div>
-        <div className="border-l-2 border-ink pl-4">
-          <ListeningStreak />
-        </div>
-      </div>
+      {/* Stat cards */}
+      <section className="grid grid-cols-1 sm:grid-cols-3 border-t border-b border-rule mb-12">
+        <StatCard
+          value={giftsThisWeek}
+          label="gifts sent"
+          sub="this week"
+          delta={
+            weekDelta != null
+              ? `${weekDelta >= 0 ? "+" : ""}${weekDelta}% vs last`
+              : undefined
+          }
+        />
+        <StatCard
+          value={uniqueArtists}
+          label="artists supported"
+          sub="all time"
+          delta={artistsThisWeek > 0 ? `${artistsThisWeek} new this week` : undefined}
+          divider
+        />
+        <StatCard
+          value={dayStreak}
+          label="day streak"
+          sub={dayStreak > 0 ? `best: ${dayStreak}d` : "start one today"}
+          delta={dayStreak > 0 ? "don't break it" : undefined}
+          divider
+        />
+      </section>
 
-      {/* Activity chart */}
       <ListeningActivity />
 
-      {/* Extension wallet */}
-      <FundExtension onWalletDetected={onExtWalletDetected} />
-
-      {/* Two-column: Top Artists + Platform Breakdown */}
-      <div className="grid sm:grid-cols-2 gap-6 mb-12">
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-10 mt-12">
         <TopArtists />
         <PlatformBreakdown />
-      </div>
+      </section>
 
-      {/* Setup — collapsible once complete */}
-      <div className="mb-12">
-        {setupComplete ? (
-          <button
-            onClick={() => setShowSetup(!showSetup)}
-            className="flex items-center gap-3 w-full text-left"
-          >
-            <h2 className="text-xs uppercase tracking-widest text-ink-faint">setup</h2>
-            <span className="text-xs text-onda font-bold">complete</span>
-            <svg
-              className={`w-3 h-3 text-ink-faint transition-transform ml-auto ${
-                showSetup ? "rotate-180" : ""
-              }`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </button>
-        ) : (
-          <h2 className="text-xs uppercase tracking-widest text-ink-faint mb-4">setup</h2>
-        )}
-
-        {(!setupComplete || showSetup) && (
-          <div className={`space-y-2 ${setupComplete ? "mt-4" : ""}`}>
-            <Check done={isConnected} label="sign in" />
-            <Check done={isHumanVerified} label="verify you're human" />
-            <Check done={!!extWalletAddr} label="extension detected" />
-            <Check done={balance > 0n} label="add funds" />
-            <Check done={uniqueArtists > 0} label="play a track" />
-          </div>
-        )}
-      </div>
-
-      {/* Recent */}
-      <div>
-        <h2 className="text-xs uppercase tracking-widest text-ink-faint mb-4">recent</h2>
-        <GiftFeed />
-      </div>
+      <section className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-12">
+        <div className="lg:col-span-2">
+          <GiftFeed />
+        </div>
+        <div>
+          <TopUpPanel onWalletDetected={onExtWalletDetected} />
+        </div>
+      </section>
     </div>
   );
 }
 
-function Check({ done, label }: { done: boolean; label: string }) {
+interface StatCardProps {
+  value: number | string;
+  label: string;
+  sub?: string;
+  delta?: string;
+  divider?: boolean;
+}
+
+function StatCard({ value, label, sub, delta, divider }: StatCardProps) {
   return (
-    <div className="flex items-center gap-3 text-sm">
-      <div className={`w-5 h-5 border-2 flex items-center justify-center ${done ? "border-onda bg-onda" : "border-rule"}`}>
-        {done && (
-          <svg className="w-3 h-3 text-paper" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-            <path strokeLinecap="square" d="M5 13l4 4L19 7" />
-          </svg>
-        )}
+    <div className={`px-5 py-7 ${divider ? "sm:border-l border-rule" : ""}`}>
+      <div className="font-mono text-4xl sm:text-5xl font-bold leading-none mb-4">
+        {value}
       </div>
-      <span className={done ? "text-ink-faint line-through" : ""}>{label}</span>
+      <div className="font-bold text-sm">{label}</div>
+      {sub && <div className="text-xs text-ink-faint mt-0.5">{sub}</div>}
+      {delta && <div className="text-xs text-onda mt-3">{delta}</div>}
     </div>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "../design/tokens.css";
+
 @layer base {
   body {
     @apply bg-paper text-ink;

--- a/apps/web/src/app/landing/components/PlatformDemo.tsx
+++ b/apps/web/src/app/landing/components/PlatformDemo.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bars } from "./Wave";
+import { PLATFORMS } from "../mock-data";
+
+/**
+ * Rotating platform demo — cycles through spotify/soundcloud/bandcamp/yt music/radio
+ * showing the onda tip overlay sliding in on each artist's "album art".
+ */
+export function PlatformDemo() {
+  const [idx, setIdx] = useState(0);
+  const [tipKey, setTipKey] = useState(0);
+  const [sent, setSent] = useState(0.03);
+  const p = PLATFORMS[idx];
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIdx((i) => (i + 1) % PLATFORMS.length);
+      setTipKey((k) => k + 1);
+      setSent((s) => s + 0.01);
+    }, 4500);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div>
+      {/* Platform tabs */}
+      <div style={{ display: "flex", gap: 0, marginBottom: -1, position: "relative", zIndex: 2 }}>
+        {PLATFORMS.map((pl, i) => (
+          <button
+            key={pl.id}
+            onClick={() => { setIdx(i); setTipKey((k) => k + 1); }}
+            className="font-mono lowercase"
+            style={{
+              padding: "10px 14px",
+              fontSize: 11,
+              letterSpacing: 1,
+              border: "1px solid var(--onda-line, rgba(13,13,13,0.12))",
+              borderBottom: idx === i ? "1px solid transparent" : "1px solid var(--onda-line, rgba(13,13,13,0.12))",
+              background: idx === i ? p.chrome : "transparent",
+              color: idx === i ? p.fg : "var(--onda-muted-2, #6B655B)",
+              cursor: "pointer",
+              flex: 1,
+              transition: "background 300ms ease, color 300ms ease",
+            }}
+          >
+            {pl.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Mock window */}
+      <div
+        key={idx}
+        style={{
+          background: p.chrome,
+          color: p.fg,
+          padding: 24,
+          position: "relative",
+          overflow: "hidden",
+          minHeight: 440,
+          border: "1px solid var(--onda-line, rgba(13,13,13,0.12))",
+          transition: "background 600ms ease, color 600ms ease",
+        }}
+      >
+        {/* chrome header */}
+        <div className="font-mono lowercase" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 20, fontSize: 10, opacity: 0.6 }}>
+          <span>{p.name} · now playing</span>
+          <div style={{ display: "flex", gap: 6 }}>
+            {[0, 1, 2].map((i) => (
+              <span key={i} style={{ width: 8, height: 8, borderRadius: "50%", background: "currentColor", opacity: 0.3 }} />
+            ))}
+          </div>
+        </div>
+
+        {/* album art */}
+        <div style={{ position: "relative", width: "100%", aspectRatio: "1", marginBottom: 16, background: p.track.art }}>
+          <div style={{ position: "absolute", inset: 0, background: "radial-gradient(ellipse at 30% 30%, rgba(255,255,255,0.22), transparent 60%)" }} />
+          <div className="font-mono lowercase" style={{ position: "absolute", left: 14, top: 14, fontSize: 9, color: "rgba(255,255,255,0.7)" }}>
+            [ artwork ]
+          </div>
+
+          {/* onda tip overlay */}
+          <div
+            key={tipKey}
+            style={{
+              position: "absolute",
+              right: 14,
+              top: 14,
+              background: "var(--onda-paper, #ECE6DB)",
+              color: "var(--onda-ink, #0D0D0D)",
+              padding: "10px 12px",
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              animation: "onda-slide-in-right 600ms cubic-bezier(.2,.7,.2,1)",
+              boxShadow: "0 6px 20px rgba(0,0,0,0.25)",
+            }}
+          >
+            <svg width="18" height="12" viewBox="0 0 28 20" fill="none">
+              <path d="M1 10 Q 5 2, 9 10 T 17 10 T 27 10" stroke="var(--onda-rust, #B8621B)" strokeWidth="2" fill="none" strokeLinecap="round" />
+            </svg>
+            <div style={{ fontSize: 11 }} className="lowercase">
+              <div className="font-mono" style={{ fontWeight: 500 }}>+$0.01 → {p.track.artist}</div>
+              <div className="font-mono" style={{ fontSize: 9, color: "var(--onda-muted-2, #6B655B)" }}>onda · sent</div>
+            </div>
+          </div>
+
+          {/* waveform */}
+          <div style={{ position: "absolute", left: 14, right: 14, bottom: 14 }}>
+            <Bars bars={60} seed={idx + 1} active height={20} color="rgba(255,255,255,0.85)" />
+          </div>
+        </div>
+
+        {/* track row */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 14 }}>
+          <div>
+            <div className="lowercase" style={{ fontSize: 17, fontWeight: 600, letterSpacing: -0.3 }}>{p.track.title}</div>
+            <div className="lowercase" style={{ fontSize: 13, opacity: 0.7, marginTop: 2 }}>{p.track.artist} · {p.track.album}</div>
+          </div>
+          <div style={{ width: 36, height: 36, borderRadius: "50%", background: p.accent, display: "flex", alignItems: "center", justifyContent: "center", color: p.chrome, fontSize: 14 }}>▶</div>
+        </div>
+
+        {/* scrubber */}
+        <div style={{ height: 3, background: "currentColor", opacity: 0.15, marginBottom: 4, position: "relative" }}>
+          <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: "38%", background: p.accent }} />
+        </div>
+        <div className="font-mono" style={{ display: "flex", justifyContent: "space-between", fontSize: 10, opacity: 0.5, marginBottom: 16 }}>
+          <span>1:42</span>
+          <span>4:28</span>
+        </div>
+
+        {/* onda status bar */}
+        <div
+          className="font-mono lowercase"
+          style={{
+            borderTop: "1px dashed rgba(255,255,255,0.15)",
+            paddingTop: 12,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: 11,
+          }}
+        >
+          <span style={{ display: "flex", alignItems: "center", gap: 8, opacity: 0.75 }}>
+            <span className="onda-live-dot" />
+            onda is listening
+          </span>
+          <span style={{ opacity: 0.9 }}>session · ${sent.toFixed(2)} sent</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/landing/components/Sections.tsx
+++ b/apps/web/src/app/landing/components/Sections.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bars } from "./Wave";
+import { LIVE_TICKER_SEED, LIVE_TICKER_LISTENERS, LIVE_TICKER_ARTISTS, LIVE_TICKER_TRACKS, LIVE_TICKER_PLATFORMS, FEATURED_ARTISTS, FAQ_ITEMS } from "../mock-data";
+import { Reveal, WordStagger } from "@/design/motion";
+
+const container = { maxWidth: 1280, margin: "0 auto", padding: "0 48px" } as const;
+
+function btn(variant: "primary" | "secondary" | "rust"): React.CSSProperties {
+  const base: React.CSSProperties = {
+    padding: "14px 22px",
+    fontSize: 14,
+    fontWeight: 600,
+    border: 0,
+    cursor: "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 10,
+    transition: "transform 120ms ease, background 120ms ease",
+    textTransform: "lowercase",
+  };
+  if (variant === "primary") return { ...base, background: "var(--onda-ink, #0D0D0D)", color: "var(--onda-paper, #ECE6DB)" };
+  if (variant === "secondary") return { ...base, background: "transparent", color: "var(--onda-ink, #0D0D0D)", border: "1.5px solid var(--onda-ink, #0D0D0D)" };
+  return { ...base, background: "var(--onda-rust, #B8621B)", color: "var(--onda-paper, #ECE6DB)" };
+}
+
+// ---------- STATS BAR ----------
+export function StatsBar() {
+  // TODO: swap the 247k number for a live count from the gift feed API
+  const stats = [
+    { value: "$0.01", label: "per listen", note: "3.3× streaming" },
+    { value: "100%", label: "to the artist", note: "no cuts. ever." },
+    { value: "0", label: "middlemen", note: "direct. full stop." },
+    { value: "247k", label: "waves sent", note: "this week" },
+  ];
+  return (
+    <section style={{ background: "var(--onda-ink, #0D0D0D)", color: "var(--onda-paper, #ECE6DB)", padding: "56px 0" }}>
+      <div style={{ ...container, display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 48 }}>
+        {stats.map((s, i) => (
+          <Reveal key={i} delay={i * 120} distance={28} duration={900} style={{ borderLeft: i > 0 ? "1px solid rgba(255,255,255,0.12)" : "none", paddingLeft: i > 0 ? 32 : 0 }}>
+            <div className="font-mono" style={{ fontSize: 40, fontWeight: 500, letterSpacing: -1, marginBottom: 8 }}>{s.value}</div>
+            <div className="lowercase" style={{ fontSize: 13, color: "var(--onda-muted, #8A8378)", marginBottom: 4 }}>{s.label}</div>
+            <div className="font-mono lowercase" style={{ fontSize: 10, color: "var(--onda-rust, #B8621B)", letterSpacing: 0.5 }}>{s.note}</div>
+          </Reveal>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------- HOW IT WORKS ----------
+export function HowItWorks() {
+  const steps = [
+    { n: "01", title: "listen to music", body: "spotify, soundcloud, bandcamp, youtube music. onda detects what's playing — quietly, in the background.", kind: "listen" as const },
+    { n: "02", title: "gifts go out", body: "each track sends a gift from your balance. if the artist hasn't claimed yet, it waits for them.", kind: "send" as const },
+    { n: "03", title: "artists collect", body: "verify identity. receive gifts directly. no signup. no email. just money — straight to you.", kind: "collect" as const },
+  ];
+  return (
+    <section style={{ padding: "100px 0", borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))" }}>
+      <div style={container}>
+        <Reveal distance={10} duration={700}>
+          <div className="font-mono lowercase" style={{ fontSize: 11, letterSpacing: 2, color: "var(--onda-muted-2, #6B655B)", marginBottom: 48 }}>how it works</div>
+        </Reveal>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 48 }}>
+          {steps.map((s, i) => (
+            <Reveal key={s.n} delay={i * 160} distance={32} duration={900}>
+              <div style={{ marginBottom: 20, height: 140, border: "1px solid var(--onda-line, rgba(13,13,13,0.12))", background: "var(--onda-paper-2, #E3DCCD)", position: "relative", overflow: "hidden" }}>
+                <StepDiagram kind={s.kind} />
+              </div>
+              <div className="onda-serif-italic" style={{ fontSize: 56, color: "var(--onda-faded, #CFC6B6)", fontWeight: 700, lineHeight: 1, marginBottom: 12 }}>{s.n}</div>
+              <div className="lowercase" style={{ fontSize: 20, fontWeight: 700, marginBottom: 10, letterSpacing: -0.3 }}>{s.title}</div>
+              <div className="lowercase" style={{ fontSize: 14, color: "var(--onda-muted-2, #6B655B)", lineHeight: 1.55 }}>{s.body}</div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StepDiagram({ kind }: { kind: "listen" | "send" | "collect" }) {
+  if (kind === "listen") {
+    return (
+      <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <div style={{ width: 200, color: "var(--onda-ink, #0D0D0D)" }}>
+          <Bars bars={40} seed={7} active height={60} color="var(--onda-ink, #0D0D0D)" />
+        </div>
+      </div>
+    );
+  }
+  if (kind === "send") {
+    return (
+      <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 24px" }}>
+        <Dot label="you" />
+        <FlowArrow />
+        <Dot label="artist" filled />
+      </div>
+    );
+  }
+  return (
+    <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ fontFamily: "JetBrains Mono, monospace", fontSize: 12, color: "var(--onda-ink, #0D0D0D)", textAlign: "center" }}>
+        <div style={{ padding: "8px 12px", border: "1px solid var(--onda-ink, #0D0D0D)", background: "var(--onda-paper, #ECE6DB)" }}>
+          direct deposit
+        </div>
+        <div style={{ marginTop: 8, color: "var(--onda-rust, #B8621B)" }}>+ $12.47</div>
+      </div>
+    </div>
+  );
+}
+
+function Dot({ label, filled }: { label: string; filled?: boolean }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ width: 40, height: 40, borderRadius: "50%", background: filled ? "var(--onda-rust, #B8621B)" : "transparent", border: "2px solid " + (filled ? "var(--onda-rust, #B8621B)" : "var(--onda-ink, #0D0D0D)") }} />
+      <div className="font-mono lowercase" style={{ fontSize: 10, marginTop: 6, color: "var(--onda-muted-2, #6B655B)" }}>{label}</div>
+    </div>
+  );
+}
+
+function FlowArrow() {
+  return (
+    <div style={{ flex: 1, position: "relative", margin: "0 12px" }}>
+      <svg viewBox="0 0 200 20" width="100%" height="20" preserveAspectRatio="none">
+        <path d="M0 10 Q 50 2, 100 10 T 200 10" stroke="var(--onda-rust, #B8621B)" strokeWidth="1.5" fill="none" />
+        <polygon points="200,10 192,6 192,14" fill="var(--onda-rust, #B8621B)" />
+      </svg>
+      <div className="font-mono" style={{ position: "absolute", top: -18, left: "50%", transform: "translateX(-50%)", fontSize: 10, color: "var(--onda-rust, #B8621B)" }}>$0.01</div>
+    </div>
+  );
+}
+
+// ---------- LIVE TICKER ----------
+export function LiveTicker() {
+  const [events, setEvents] = useState(LIVE_TICKER_SEED);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const e = {
+        id: Math.random(),
+        listener: LIVE_TICKER_LISTENERS[Math.floor(Math.random() * LIVE_TICKER_LISTENERS.length)],
+        artist: LIVE_TICKER_ARTISTS[Math.floor(Math.random() * LIVE_TICKER_ARTISTS.length)],
+        track: LIVE_TICKER_TRACKS[Math.floor(Math.random() * LIVE_TICKER_TRACKS.length)],
+        platform: LIVE_TICKER_PLATFORMS[Math.floor(Math.random() * LIVE_TICKER_PLATFORMS.length)],
+        amt: 0.01,
+      };
+      setEvents((prev) => [e, ...prev.slice(0, 5)]);
+    }, 2200);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <section style={{ padding: "100px 0", borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))" }}>
+      <div style={container}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1.2fr", gap: 80, alignItems: "start" }}>
+          <div>
+            <div className="font-mono lowercase" style={{ fontSize: 11, letterSpacing: 2, color: "var(--onda-muted-2, #6B655B)", marginBottom: 24 }}>live feed</div>
+            <h2 className="lowercase" style={{ fontSize: 56, lineHeight: 0.95, fontWeight: 800, letterSpacing: -1.8, margin: "0 0 24px" }}>
+              <WordStagger text="every" step={60} distance={28} />{" "}
+              <WordStagger delay={150} text="wave" step={60} distance={28} className="onda-serif-italic" style={{ color: "var(--onda-rust, #B8621B)" }} />
+              <br />
+              <WordStagger delay={300} text="is public." step={60} distance={28} />
+            </h2>
+            <p className="lowercase" style={{ fontSize: 16, color: "var(--onda-muted-2, #6B655B)", lineHeight: 1.55, maxWidth: 380 }}>
+              no balance sheet. no quarterly report. every tip is posted publicly, in real time — so listeners can see who they're supporting, and artists can see what's landing.
+            </p>
+            <button style={{ ...btn("secondary"), marginTop: 28 }}>see the full feed →</button>
+          </div>
+          <div style={{ background: "var(--onda-paper-2, #E3DCCD)", border: "1px solid var(--onda-line, rgba(13,13,13,0.12))" }}>
+            <div className="font-mono lowercase" style={{ fontSize: 10, letterSpacing: 1.5, color: "var(--onda-muted-2, #6B655B)", padding: "14px 20px", borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))", display: "flex", justifyContent: "space-between" }}>
+              <span>recent tips</span>
+              <span>listener / track / amount</span>
+            </div>
+            {events.map((e, i) => (
+              <div
+                key={e.id}
+                style={{
+                  padding: "16px 20px",
+                  display: "grid",
+                  gridTemplateColumns: "80px 1fr 70px 60px",
+                  gap: 16,
+                  alignItems: "center",
+                  borderBottom: i < events.length - 1 ? "1px solid var(--onda-line, rgba(13,13,13,0.12))" : "none",
+                  fontSize: 13,
+                  opacity: i === 0 ? 1 : Math.max(0.4, 1 - i * 0.12),
+                  transition: "opacity 400ms ease",
+                }}
+              >
+                <span className="font-mono lowercase" style={{ color: "var(--onda-muted-2, #6B655B)" }}>@{e.listener}</span>
+                <span className="lowercase">
+                  <span style={{ color: "var(--onda-ink, #0D0D0D)" }}>{e.track}</span>
+                  <span style={{ color: "var(--onda-muted-2, #6B655B)" }}> · {e.artist}</span>
+                </span>
+                <span className="font-mono" style={{ color: "var(--onda-rust, #B8621B)" }}>+${e.amt.toFixed(2)}</span>
+                <span className="font-mono lowercase" style={{ fontSize: 10, color: "var(--onda-muted-2, #6B655B)", textAlign: "right" }}>{e.platform}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------- ARTIST SPOTLIGHT ----------
+export function ArtistSpotlight() {
+  return (
+    <section style={{ padding: "100px 0", borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))" }}>
+      <div style={container}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", marginBottom: 48 }}>
+          <div>
+            <div className="font-mono lowercase" style={{ fontSize: 11, letterSpacing: 2, color: "var(--onda-muted-2, #6B655B)", marginBottom: 16 }}>artists receiving waves</div>
+            <h2 className="lowercase" style={{ fontSize: 56, lineHeight: 0.95, fontWeight: 800, letterSpacing: -1.8, margin: 0 }}>
+              <WordStagger text="paid in" step={70} distance={28} />{" "}
+              <WordStagger delay={200} text="full." step={70} distance={28} className="onda-serif-italic" style={{ color: "var(--onda-rust, #B8621B)" }} />
+            </h2>
+            <p className="lowercase" style={{ fontSize: 15, color: "var(--onda-muted-2, #6B655B)", marginTop: 16, maxWidth: 440, lineHeight: 1.5 }}>
+              onda works best for the artists streaming pays worst — the ones in the long tail, the ones whose fans would happily give more if they could.
+            </p>
+          </div>
+          <button style={btn("secondary")}>browse all artists →</button>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 24 }}>
+          {FEATURED_ARTISTS.map((a, i) => (
+            <ArtistCard key={i} artist={a} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ArtistCard({ artist, index }: { artist: typeof FEATURED_ARTISTS[number]; index: number }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        border: "1px solid var(--onda-line, rgba(13,13,13,0.12))",
+        background: "var(--onda-paper-2, #E3DCCD)",
+        display: "grid",
+        gridTemplateColumns: "180px 1fr",
+        position: "relative",
+        transition: "transform 200ms ease",
+        transform: hover ? "translateY(-2px)" : "none",
+      }}
+    >
+      <div style={{ position: "relative", minHeight: 220, background: artist.art, overflow: "hidden" }}>
+        <div style={{ position: "absolute", inset: 0, background: "radial-gradient(ellipse at 30% 30%, rgba(255,255,255,0.18), transparent 60%)" }} />
+        <div className="font-mono lowercase" style={{ position: "absolute", left: 10, top: 10, fontSize: 9, color: "rgba(255,255,255,0.7)" }}>[ {artist.artNote} ]</div>
+        <div style={{ position: "absolute", left: 12, right: 12, bottom: 12 }}>
+          <Bars bars={34} seed={index + 7} active={hover} height={22} color="rgba(255,255,255,0.9)" />
+        </div>
+      </div>
+
+      <div style={{ padding: 20, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+        <div>
+          <div style={{ marginBottom: 10 }}>
+            <div className="lowercase" style={{ fontSize: 18, fontWeight: 700, letterSpacing: -0.3 }}>{artist.name}</div>
+            <div className="lowercase" style={{ fontSize: 11, color: "var(--onda-muted-2, #6B655B)", marginTop: 2 }}>{artist.tag} · {artist.loc}</div>
+          </div>
+          <div className="lowercase" style={{ fontSize: 12, color: "var(--onda-ink, #0D0D0D)", fontStyle: "italic", lineHeight: 1.45, borderLeft: "2px solid var(--onda-rust, #B8621B)", paddingLeft: 10, margin: "10px 0 14px" }}>
+            "{artist.quote}"
+          </div>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 12 }}>
+            {artist.handles.map((h, i) => (
+              <span key={i} className="font-mono lowercase" style={{ fontSize: 10, padding: "3px 7px", border: "1px solid var(--onda-line, rgba(13,13,13,0.12))", background: "var(--onda-paper, #ECE6DB)" }}>
+                <span style={{ color: "var(--onda-rust, #B8621B)" }}>{h.p}</span> <span style={{ color: "var(--onda-muted-2, #6B655B)" }}>{h.h}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: "1px solid var(--onda-line, rgba(13,13,13,0.12))", paddingTop: 10 }}>
+          <div>
+            <div className="font-mono" style={{ fontSize: 18, fontWeight: 500, color: "var(--onda-rust, #B8621B)" }}>{artist.earned}</div>
+            <div className="font-mono lowercase" style={{ fontSize: 9, color: "var(--onda-muted-2, #6B655B)" }}>received · 30d</div>
+          </div>
+          <div style={{ textAlign: "right" }}>
+            <div className="font-mono" style={{ fontSize: 14, color: "var(--onda-ink, #0D0D0D)" }}>{artist.plays}</div>
+            <div className="font-mono lowercase" style={{ fontSize: 9, color: "var(--onda-muted-2, #6B655B)" }}>plays · 30d</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- MANIFESTO ----------
+export function Manifesto() {
+  return (
+    <section style={{ padding: "120px 0", background: "var(--onda-ink, #0D0D0D)", color: "var(--onda-paper, #ECE6DB)", position: "relative", overflow: "hidden" }}>
+      <div style={{ ...container, position: "relative" }}>
+        <div className="font-mono lowercase" style={{ fontSize: 11, letterSpacing: 2, color: "var(--onda-muted, #8A8378)", marginBottom: 32 }}>manifesto · 01</div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: 80, alignItems: "start" }}>
+          <div style={{ position: "sticky", top: 40 }}>
+            <div className="onda-serif-italic" style={{ fontSize: 120, fontWeight: 700, lineHeight: 0.9, color: "var(--onda-rust, #B8621B)" }}>"</div>
+          </div>
+          <div>
+            <p className="lowercase" style={{ fontSize: 32, lineHeight: 1.3, fontWeight: 500, letterSpacing: -0.5, margin: "0 0 32px" }}>
+              a stream is worth <span style={{ color: "var(--onda-rust, #B8621B)" }}>three tenths of a cent</span>. that's what the industry decided. we disagree.
+            </p>
+            <p className="lowercase" style={{ fontSize: 19, lineHeight: 1.6, color: "var(--onda-muted, #8A8378)", maxWidth: 640, margin: "0 0 24px" }}>
+              the internet routes packets across the world for free. money should move just as easily. the excuse for why artists get paid in fractions of pennies doesn't hold up anymore.
+            </p>
+            <p className="lowercase" style={{ fontSize: 19, lineHeight: 1.6, color: "var(--onda-muted, #8A8378)", maxWidth: 640, margin: 0 }}>
+              onda is a browser extension. it watches what you listen to. it sends a small tip — one cent — straight to the artist. that's the whole product. there is nothing else to build.
+            </p>
+            <div className="font-mono lowercase" style={{ fontSize: 12, color: "var(--onda-muted-2, #6B655B)", marginTop: 40, letterSpacing: 1 }}>— the onda team, brooklyn ny</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------- FAQ ----------
+export function FAQ() {
+  const [open, setOpen] = useState(0);
+  return (
+    <section style={{ padding: "100px 0", borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))" }}>
+      <div style={container}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: 80, alignItems: "start" }}>
+          <div>
+            <div className="font-mono lowercase" style={{ fontSize: 11, letterSpacing: 2, color: "var(--onda-muted-2, #6B655B)", marginBottom: 16 }}>questions</div>
+            <h2 className="lowercase" style={{ fontSize: 56, lineHeight: 0.95, fontWeight: 800, letterSpacing: -1.8, margin: 0 }}>
+              <WordStagger text="straight" step={70} distance={28} />
+              <br />
+              <WordStagger delay={200} text="answers." step={70} distance={28} className="onda-serif-italic" style={{ color: "var(--onda-rust, #B8621B)" }} />
+            </h2>
+          </div>
+          <div>
+            {FAQ_ITEMS.map((it, i) => (
+              <div key={i} style={{ borderTop: "1px solid var(--onda-line, rgba(13,13,13,0.12))", borderBottom: i === FAQ_ITEMS.length - 1 ? "1px solid var(--onda-line, rgba(13,13,13,0.12))" : "none" }}>
+                <button
+                  onClick={() => setOpen(open === i ? -1 : i)}
+                  style={{ width: "100%", padding: "22px 0", background: "none", border: 0, cursor: "pointer", display: "flex", justifyContent: "space-between", alignItems: "center", textAlign: "left", color: "var(--onda-ink, #0D0D0D)" }}
+                >
+                  <span style={{ display: "flex", gap: 20, alignItems: "baseline" }}>
+                    <span className="font-mono" style={{ fontSize: 12, color: "var(--onda-muted-2, #6B655B)" }}>{String(i + 1).padStart(2, "0")}</span>
+                    <span className="lowercase" style={{ fontSize: 19, fontWeight: 600 }}>{it.q}</span>
+                  </span>
+                  <span style={{ fontSize: 20, color: "var(--onda-rust, #B8621B)", transform: open === i ? "rotate(45deg)" : "none", transition: "transform 200ms ease" }}>+</span>
+                </button>
+                {open === i && (
+                  <div className="lowercase" style={{ paddingLeft: 52, paddingBottom: 22, fontSize: 15, color: "var(--onda-muted-2, #6B655B)", lineHeight: 1.6, maxWidth: 560 }}>
+                    {it.a}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/landing/components/Wave.tsx
+++ b/apps/web/src/app/landing/components/Wave.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * Continuous animated background wave — used in the hero and CTA.
+ * Stand-alone, no props besides intensity.
+ */
+import { useEffect, useState } from "react";
+
+interface WaveProps {
+  intensity?: number;
+  color?: string;
+  subtle?: boolean;
+}
+
+export function Wave({ intensity = 1, color = "var(--onda-rust, #B8621B)", subtle = false }: WaveProps) {
+  const [t, setT] = useState(0);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+    let raf: number;
+    const loop = () => {
+      setT(performance.now() / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const W = 800;
+  const H = 240;
+  const lines = subtle ? 1 : 5;
+  const paths: { d: string; op: number }[] = [];
+  for (let i = 0; i < lines; i++) {
+    const pts: string[] = [];
+    const freq = 0.012 + i * 0.003;
+    const speed = 1 + i * 0.15;
+    const amp = (subtle ? 18 : 36) * intensity * (1 - i * 0.12);
+    const phase = t * speed + i * 0.7;
+    for (let x = 0; x <= W; x += 6) {
+      const y =
+        H / 2 +
+        Math.sin(x * freq + phase) * amp +
+        Math.sin(x * freq * 2.1 + phase * 0.7) * amp * 0.35 +
+        Math.sin(x * freq * 0.5 + phase * 1.3) * amp * 0.5;
+      pts.push(`${x},${y.toFixed(2)}`);
+    }
+    paths.push({ d: `M ${pts.join(" L ")}`, op: subtle ? 0.15 : 0.15 + i * 0.12 });
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height="100%" preserveAspectRatio="none" style={{ display: "block" }} aria-hidden>
+      <defs>
+        <linearGradient id="onda-wave-fade" x1="0" x2="1">
+          <stop offset="0" stopColor={color} stopOpacity="0" />
+          <stop offset="0.15" stopColor={color} stopOpacity="1" />
+          <stop offset="0.85" stopColor={color} stopOpacity="1" />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {paths.map((p, i) => (
+        <path key={i} d={p.d} fill="none" stroke="url(#onda-wave-fade)" strokeOpacity={p.op} strokeWidth={subtle ? 1 : 1.5} />
+      ))}
+    </svg>
+  );
+}
+
+/** Compact vertical-bar waveform, seeded so each rendering is stable. */
+interface BarsProps {
+  bars?: number;
+  seed?: number;
+  active?: boolean;
+  color?: string;
+  height?: number;
+}
+export function Bars({ bars = 40, seed = 1, active = false, color = "currentColor", height = 28 }: BarsProps) {
+  const values = (() => {
+    const arr: number[] = [];
+    let s = seed * 9301 + 49297;
+    for (let i = 0; i < bars; i++) {
+      s = (s * 9301 + 49297) % 233280;
+      arr.push(0.2 + (s / 233280) * 0.8);
+    }
+    return arr;
+  })();
+
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    if (typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const id = setInterval(() => setTick((t) => t + 1), 120);
+    return () => clearInterval(id);
+  }, [active]);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 2, height }}>
+      {values.map((v, i) => {
+        const mod = active ? 0.6 + 0.4 * Math.abs(Math.sin((tick + i) * 0.7)) : 1;
+        return (
+          <div
+            key={i}
+            style={{
+              width: 2,
+              height: `${v * mod * 100}%`,
+              background: color,
+              borderRadius: 1,
+              transition: "height 120ms ease",
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/landing/mock-data.ts
+++ b/apps/web/src/app/landing/mock-data.ts
@@ -1,0 +1,123 @@
+/**
+ * Mock data for the landing page.
+ *
+ * TODO: swap each section for real data from the API / CMS / DB.
+ * Marked with `// TODO:` comments where the swap points are.
+ */
+
+// TODO: swap for real platforms the extension currently supports
+export const PLATFORMS = [
+  {
+    id: "spotify",
+    name: "spotify",
+    chrome: "#121212",
+    fg: "#ffffff",
+    accent: "#1DB954",
+    track: { title: "parliaments knell", artist: "loraine james", album: "reflection", art: "#3A4A6B" },
+  },
+  {
+    id: "soundcloud",
+    name: "soundcloud",
+    chrome: "#F2F2F2",
+    fg: "#1a1a1a",
+    accent: "#FF5500",
+    track: { title: "zone 1 to 6000", artist: "iglooghost", album: "lei line eon", art: "#D4B343" },
+  },
+  {
+    id: "bandcamp",
+    name: "bandcamp",
+    chrome: "#408EA3",
+    fg: "#ffffff",
+    accent: "#619AAF",
+    track: { title: "fountain", artist: "claire rousay", album: "sentiment", art: "#BF7A52" },
+  },
+  {
+    id: "ytmusic",
+    name: "youtube music",
+    chrome: "#030303",
+    fg: "#ffffff",
+    accent: "#FF0033",
+    track: { title: "pool & i", artist: "astrid sonne", album: "great doubt", art: "#5E6B4A" },
+  },
+  {
+    id: "radio",
+    name: "online radio",
+    chrome: "#1A1A1A",
+    fg: "#F2EAD3",
+    accent: "#F2EAD3",
+    track: { title: "live on air", artist: "community station", album: "streaming worldwide", art: "#8B2D2D" },
+  },
+] as const;
+
+// TODO: swap for top artists by last 30d gift volume
+export const FEATURED_ARTISTS = [
+  {
+    name: "loraine james",
+    tag: "experimental electronic",
+    loc: "london, uk",
+    earned: "$482.17",
+    plays: "48,217",
+    art: "linear-gradient(135deg, #2A3A5B 0%, #6B4A8C 50%, #D97B4A 100%)",
+    artNote: "glitched club topography",
+    handles: [{ p: "IG", h: "@loraine.james" }, { p: "BC", h: "loraine-james" }],
+    quote: "every play lands. even the weird ones.",
+  },
+  {
+    name: "claire rousay",
+    tag: "emo ambient / field recording",
+    loc: "san antonio, tx",
+    earned: "$311.08",
+    plays: "31,108",
+    art: "repeating-linear-gradient(0deg, #D8CFB8 0 8px, #BFB7A0 8px 9px), radial-gradient(circle at 30% 40%, #A67550, transparent 50%)",
+    artNote: "voicemail + reed organ",
+    handles: [{ p: "IG", h: "@clairerousay" }, { p: "BC", h: "clairerousay" }],
+    quote: "somebody tipped me for a 42-minute piece. thank you.",
+  },
+  {
+    name: "iglooghost",
+    tag: "sound collage / fantasy bass",
+    loc: "bristol, uk",
+    earned: "$729.44",
+    plays: "72,944",
+    art: "conic-gradient(from 45deg at 60% 40%, #E8C044, #FF6B35, #2B2D42, #E8C044)",
+    artNote: "lei line cartography, vol ii",
+    handles: [{ p: "IG", h: "@iglooghost" }, { p: "SC", h: "iglooghost" }],
+    quote: "pennies from strangers. love that for me.",
+  },
+  {
+    name: "astrid sonne",
+    tag: "viola / song-form minimalism",
+    loc: "copenhagen, dk",
+    earned: "$256.90",
+    plays: "25,690",
+    art: "linear-gradient(180deg, #8FA67A 0%, #4A5A3E 60%, #2B2D23 100%)",
+    artNote: "great doubt, b-side sketches",
+    handles: [{ p: "IG", h: "@astridsonne" }, { p: "BC", h: "astridsonne" }],
+    quote: "better than my last publishing statement.",
+  },
+] as const;
+
+// TODO: swap for live data from the gift feed
+export const LIVE_TICKER_SEED = [
+  { id: 1, listener: "em", artist: "loraine james", track: "afterglow", platform: "spotify", amt: 0.01 },
+  { id: 2, listener: "theo", artist: "claire rousay", track: "fountain", platform: "bandcamp", amt: 0.01 },
+  { id: 3, listener: "sasha", artist: "iglooghost", track: "zone 6", platform: "soundcloud", amt: 0.01 },
+  { id: 4, listener: "noor", artist: "astrid sonne", track: "pool & i", platform: "yt music", amt: 0.01 },
+  { id: 5, listener: "jules", artist: "ana roxanne", track: "venus", platform: "spotify", amt: 0.01 },
+  { id: 6, listener: "ren", artist: "space afrika", track: "bê", platform: "bandcamp", amt: 0.01 },
+];
+
+export const LIVE_TICKER_LISTENERS = ["em", "theo", "sasha", "noor", "jules", "ren", "mika", "kai", "ida", "leo", "sun", "ava"];
+export const LIVE_TICKER_ARTISTS = ["loraine james", "claire rousay", "iglooghost", "astrid sonne", "ana roxanne", "space afrika", "m. sage", "kara-lis coverdale", "upsammy", "perila"];
+export const LIVE_TICKER_TRACKS = ["afterglow", "cotton", "zone 6", "bloom", "slow tide", "low field", "second night", "halo", "still life"];
+export const LIVE_TICKER_PLATFORMS = ["spotify", "bandcamp", "soundcloud", "yt music"];
+
+export const FAQ_ITEMS = [
+  { q: "can i pay artists more than a cent?", a: "yes — onda has a direct tip button ($1, $5, $20, custom) and an artist-run storefront for merch, vinyl, zines, sample packs. artists set the prices and fulfill orders themselves. you pay them directly. no cut." },
+  { q: "how much does onda cost?", a: "the extension is free. you choose how much to allocate per play — the default is one cent. no subscription, no platform fee." },
+  { q: "does the artist need an account?", a: "no. tips accrue against the artist's name until they verify and claim. unclaimed gifts wait indefinitely — some artists have years of waves waiting for them." },
+  { q: "how do artists get paid?", a: "in dollars. we handle the plumbing. artists can withdraw to their bank, or keep a running balance on onda." },
+  { q: "how does detection work?", a: "the extension reads the currently-playing track from the tab's media session api. it never sees anything else on the page." },
+  { q: "can labels take a cut?", a: "not through onda. 100% of what you send goes to the verified artist — no exceptions." },
+  { q: "what if i don't have a balance?", a: "top up with a card in 30 seconds. minimum is $3. stop any time." },
+];

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,18 @@
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
+import { Inter, JetBrains_Mono, Fraunces } from "next/font/google";
+import { WaveMark } from "@/design/marks/WaveMark";
 import "@rainbow-me/rainbowkit/styles.css";
 import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  style: ["italic"],
+  weight: ["700"],
+  variable: "--font-fraunces",
+});
 
 const Providers = dynamic(() => import("./providers").then((m) => m.Providers), {
   ssr: false,
@@ -24,14 +35,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${mono.variable} ${fraunces.variable}`}>
       <body className="min-h-screen">
         <Providers>
           <nav className="border-b border-rule">
             <div className="max-w-4xl mx-auto px-5 sm:px-8">
               <div className="flex justify-between items-center h-14">
-                <a href="/" className="text-lg font-bold tracking-tight">
-                  onda
+                <a href="/" aria-label="onda — home" className="text-ink hover:text-onda transition-colors">
+                  <WaveMark height={22} />
                 </a>
                 <div className="flex items-center gap-6">
                   <a href="/dashboard" className="text-ink-light hover:text-ink transition-colors text-sm">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,176 +1,141 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
+import { Reveal, SplitReveal, WordStagger, MarqueeLine } from "@/design/motion";
+import { Wave } from "./landing/components/Wave";
+import { PlatformDemo } from "./landing/components/PlatformDemo";
+import { StatsBar, HowItWorks, LiveTicker, ArtistSpotlight, Manifesto, FAQ } from "./landing/components/Sections";
+
+const container = { maxWidth: 1280, margin: "0 auto", padding: "0 48px" } as const;
+
+function btn(variant: "primary" | "secondary"): React.CSSProperties {
+  const base: React.CSSProperties = {
+    padding: "14px 22px", fontSize: 14, fontWeight: 600, border: 0, cursor: "pointer",
+    display: "inline-flex", alignItems: "center", gap: 10, textTransform: "lowercase",
+    transition: "background 120ms ease",
+  };
+  if (variant === "primary") return { ...base, background: "var(--onda-ink, #0D0D0D)", color: "var(--onda-paper, #ECE6DB)" };
+  return { ...base, background: "transparent", color: "var(--onda-ink, #0D0D0D)", border: "1.5px solid var(--onda-ink, #0D0D0D)" };
+}
+
+function PlatformChip({ name }: { name: string }) {
+  return (
+    <span style={{ border: "1px solid var(--onda-line, rgba(13,13,13,0.12))", borderRadius: 999, padding: "4px 10px", fontSize: 11, background: "rgba(255,255,255,0.3)" }}>
+      {name}
+    </span>
+  );
+}
 
 export default function Home() {
+  // onClick stubs — the existing app already has /claim + /onda.zip wired up.
+  const onDownload = () => { window.location.href = "/onda.zip"; };
+
   return (
-    <div className="min-h-[calc(100vh-3.5rem)]">
-      {/* Hero */}
-      <section className="max-w-4xl mx-auto px-5 sm:px-8 pt-20 pb-16">
-        <h1 className="text-5xl sm:text-7xl font-bold tracking-tight leading-[0.95] mb-6 max-w-lg">
-          every play
-          <br />
-          sends a
-          <br />
-          <span className="text-onda">wave.</span>
-        </h1>
-        <p className="text-ink-light text-lg max-w-md mb-8 leading-snug">
-          Spotify sends artists $0.003 per stream.
-          onda lets you give them $0.01 directly.
-        </p>
-        <div className="flex gap-3 flex-wrap">
-          <a href="/onda.zip" download className="btn-primary">
-            download extension
-          </a>
-          <Link href="/claim" className="btn-secondary">
-            i'm an artist
-          </Link>
-        </div>
-      </section>
-
-      {/* Numbers — big monospace in inverted bar */}
-      <section className="ink-block">
-        <div className="max-w-4xl mx-auto px-5 sm:px-8 py-8">
-          <div className="grid grid-cols-3 gap-6">
-            <div>
-              <div className="font-mono text-3xl sm:text-4xl font-bold tracking-tight">$0.01</div>
-              <div className="text-sm text-paper/50 mt-1">per listen</div>
-            </div>
-            <div>
-              <div className="font-mono text-3xl sm:text-4xl font-bold tracking-tight">100%</div>
-              <div className="text-sm text-paper/50 mt-1">to the artist</div>
-            </div>
-            <div>
-              <div className="font-mono text-3xl sm:text-4xl font-bold tracking-tight">0</div>
-              <div className="text-sm text-paper/50 mt-1">middlemen</div>
-            </div>
+    <div data-screen-label="01 Landing">
+      {/* ---------- HERO ---------- */}
+      <section style={{ position: "relative", padding: "80px 0 100px", overflow: "hidden" }}>
+        <div style={{ position: "absolute", inset: 0, opacity: 0.5, pointerEvents: "none" }}>
+          <div style={{ position: "absolute", right: "-5%", top: "10%", width: "65%", height: "60%" }}>
+            <Wave intensity={1} />
           </div>
         </div>
-      </section>
 
-      {/* How it works */}
-      <section className="max-w-4xl mx-auto px-5 sm:px-8 py-16">
-        <h2 className="text-xs uppercase tracking-widest text-ink-faint mb-10">How it works</h2>
-        <div className="grid md:grid-cols-3 gap-10">
+        <div style={{ ...container, position: "relative", display: "grid", gridTemplateColumns: "1.1fr 1fr", gap: 60, alignItems: "start" }}>
           <div>
-            <div className="text-5xl font-bold text-onda/20 leading-none mb-3">01</div>
-            <h3 className="text-lg font-bold mb-2">listen to music</h3>
-            <p className="text-ink-light text-sm leading-relaxed">
-              Spotify, SoundCloud, Bandcamp, YouTube Music.
-              onda detects what's playing.
-            </p>
-          </div>
-          <div>
-            <div className="text-5xl font-bold text-onda/20 leading-none mb-3">02</div>
-            <h3 className="text-lg font-bold mb-2">gifts go out</h3>
-            <p className="text-ink-light text-sm leading-relaxed">
-              each track sends a gift from your balance.
-              if the artist hasn't claimed yet, it waits for them.
-            </p>
-          </div>
-          <div>
-            <div className="text-5xl font-bold text-onda/20 leading-none mb-3">03</div>
-            <h3 className="text-lg font-bold mb-2">artists collect</h3>
-            <p className="text-ink-light text-sm leading-relaxed">
-              verify identity. receive gifts directly.
-              no signup. no email. just money.
-            </p>
-          </div>
-        </div>
-      </section>
+            <Reveal delay={0} distance={14} duration={700}>
+              <div className="font-mono lowercase" style={{ fontSize: 11, color: "var(--onda-muted-2, #6B655B)", letterSpacing: 1.5, marginBottom: 24, display: "flex", alignItems: "center", gap: 10 }}>
+                <span className="onda-live-dot" />
+                live · tipping artists right now
+              </div>
+            </Reveal>
 
-      {/* Extension preview + platforms */}
-      <section className="border-t border-rule">
-        <div className="max-w-4xl mx-auto px-5 sm:px-8 py-16">
-          <div className="flex flex-col md:flex-row gap-12 items-start">
-            <div className="flex-1">
-              <h2 className="text-2xl font-bold mb-3">the extension sits in your toolbar</h2>
-              <p className="text-ink-light text-sm leading-relaxed mb-6 max-w-sm">
-                it watches what you listen to and sends a gift to every artist.
-                you don't have to do anything. just listen.
+            <SplitReveal
+              as="h1"
+              tokens={[
+                "every play",
+                { br: true },
+                "sends a",
+                { br: true },
+                { node: <span className="onda-serif-italic" style={{ color: "var(--onda-rust, #B8621B)" }}>wave.</span> },
+              ]}
+              step={80}
+              distance={40}
+              duration={1000}
+              style={{
+                fontSize: 108, lineHeight: 0.92, fontWeight: 800, letterSpacing: -3.5,
+                margin: "0 0 32px", color: "var(--onda-ink, #0D0D0D)", textTransform: "lowercase",
+              }}
+            />
+
+            <Reveal delay={500} distance={14} duration={700}>
+              <p className="lowercase" style={{ fontSize: 18, lineHeight: 1.5, color: "var(--onda-muted-2, #6B655B)", maxWidth: 440, margin: "0 0 40px" }}>
+                streaming pays artists a third of a penny per play.<br />
+                onda lets you give them <strong style={{ color: "var(--onda-ink, #0D0D0D)" }}>a whole cent directly</strong>.
+                no labels. no middlemen. just sound.
               </p>
-              <a href="/onda.zip" download className="btn-primary inline-block mb-5">
-                download extension
-              </a>
-              <div className="flex flex-wrap gap-2">
-                {["Spotify", "SoundCloud", "Bandcamp", "YouTube Music"].map((p) => (
-                  <span key={p} className="text-xs border border-rule px-3 py-1.5 hover:border-ink transition-colors">
-                    {p}
-                  </span>
-                ))}
-              </div>
-            </div>
-            {/* Mini popup mock */}
-            <div className="w-[240px] shrink-0 border border-rule bg-paper-dark shadow-[6px_6px_0_0_rgba(21,19,17,0.06)]">
-              <div className="bg-ink text-paper px-4 py-2.5 flex justify-between items-baseline">
-                <span className="font-bold text-sm">onda</span>
-                <span className="text-onda text-xs font-mono">$1.40</span>
-              </div>
-              <div className="p-4">
-                <div className="text-xs text-ink-faint uppercase tracking-widest mb-2">now listening</div>
-                <div className="font-bold text-lg leading-tight">Burial</div>
-                <div className="text-ink-light text-sm">Untrue -- "Archangel"</div>
-                <div className="mt-3 border-t border-rule pt-3 space-y-1.5 text-xs">
-                  <div className="flex justify-between">
-                    <span className="text-ink-light">sent</span>
-                    <span className="text-onda font-bold">$0.01</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-ink-light">total to Burial</span>
-                    <span className="font-mono">$1.40</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-ink-light">supporters</span>
-                    <span className="font-mono">47</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+            </Reveal>
+
+            <Reveal delay={700} distance={14} duration={700} style={{ display: "flex", gap: 12, marginBottom: 32 }}>
+              <button onClick={onDownload} style={btn("primary")}>
+                <span>download extension</span>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>↓</span>
+              </button>
+              <Link href="/claim" style={btn("secondary")}>i'm an artist</Link>
+            </Reveal>
+
+            <Reveal delay={850} distance={10} duration={700} className="lowercase" style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12, color: "var(--onda-muted-2, #6B655B)", flexWrap: "wrap" }}>
+              <span>works with</span>
+              <PlatformChip name="spotify" />
+              <PlatformChip name="soundcloud" />
+              <PlatformChip name="bandcamp" />
+              <PlatformChip name="youtube" />
+              <PlatformChip name="online radio" />
+            </Reveal>
+          </div>
+
+          <PlatformDemo />
+        </div>
+      </section>
+
+      <StatsBar />
+
+      <div style={{ borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))", padding: "14px 0", background: "var(--onda-paper-2, #E3DCCD)" }}>
+        <MarqueeLine text="every play sends a wave · direct to artists · no middlemen · a whole cent · listen generously" speed={60} />
+      </div>
+
+      <HowItWorks />
+
+      <div style={{ borderBottom: "1px solid var(--onda-line, rgba(13,13,13,0.12))", padding: "14px 0", background: "var(--onda-paper-2, #E3DCCD)" }}>
+        <MarqueeLine text="claire rousay · loraine james · iglooghost · astrid sonne · perila · nkisi · jasmine infiniti · upsammy · mica levi" speed={80} color="var(--onda-rust, #B8621B)" />
+      </div>
+
+      <LiveTicker />
+      <ArtistSpotlight />
+      <Manifesto />
+      <FAQ />
+
+      {/* ---------- CTA ---------- */}
+      <section style={{ padding: "140px 0 120px", textAlign: "center", position: "relative", overflow: "hidden" }}>
+        <div style={{ position: "absolute", left: 0, right: 0, top: "50%", transform: "translateY(-50%)", height: 300, opacity: 0.4 }}>
+          <Wave intensity={1.3} />
+        </div>
+        <div style={{ ...container, position: "relative" }}>
+          <h2 className="lowercase" style={{ fontSize: 140, lineHeight: 0.9, fontWeight: 800, letterSpacing: -5, margin: "0 0 32px" }}>
+            <WordStagger text="send a" step={90} distance={60} />{" "}
+            <WordStagger delay={250} text="wave." step={90} distance={60} className="onda-serif-italic" style={{ color: "var(--onda-rust, #B8621B)" }} />
+          </h2>
+          <p className="lowercase" style={{ fontSize: 20, color: "var(--onda-muted-2, #6B655B)", marginBottom: 40 }}>
+            free. takes ten seconds. works everywhere you listen.
+          </p>
+          <div style={{ display: "flex", justifyContent: "center", gap: 12 }}>
+            <button onClick={onDownload} style={{ ...btn("primary"), padding: "18px 28px", fontSize: 15 }}>
+              download for chrome ↓
+            </button>
+            <button style={{ ...btn("secondary"), padding: "18px 28px", fontSize: 15 }}>firefox · safari</button>
           </div>
         </div>
       </section>
-
-      {/* Artist CTA */}
-      <section className="ink-block">
-        <div className="max-w-4xl mx-auto px-5 sm:px-8 py-12 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
-          <div>
-            <h2 className="text-2xl font-bold mb-1">are you an artist?</h2>
-            <p className="text-paper/60 text-sm">
-              people might already be giving to you. claim your profile.
-            </p>
-          </div>
-          <Link href="/claim" className="border border-paper/30 px-6 py-3 text-sm hover:bg-paper hover:text-ink transition-all text-center shrink-0">
-            claim profile
-          </Link>
-        </div>
-      </section>
-
-      {/* Final CTA */}
-      <section className="max-w-4xl mx-auto px-5 sm:px-8 py-16">
-        <p className="text-ink-light text-lg mb-5 max-w-md leading-snug">
-          add some funds and onda handles the rest.
-          every artist you listen to gets something.
-        </p>
-        <div className="flex gap-3">
-          <a href="/onda.zip" download className="btn-primary">
-            download extension
-          </a>
-          <Link href="/dashboard" className="btn-secondary">
-            get started
-          </Link>
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="border-t border-rule py-5">
-        <div className="max-w-4xl mx-auto px-5 sm:px-8 flex justify-between items-center">
-          <span className="text-xs text-ink-faint">buena onda</span>
-          <a
-            href="https://github.com/alaskaisprettyokay/patron-app"
-            className="text-xs text-ink-faint hover:text-ink transition-colors"
-          >
-            source
-          </a>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/apps/web/src/components/ConnectButtonWrapper.tsx
+++ b/apps/web/src/components/ConnectButtonWrapper.tsx
@@ -7,7 +7,7 @@ const ClientConnectButton = dynamic(
     import("@rainbow-me/rainbowkit").then((mod) => {
       const { ConnectButton } = mod;
       return function RainbowButton() {
-        return <ConnectButton showBalance={false} chainStatus="icon" accountStatus="avatar" />;
+        return <ConnectButton showBalance={false} chainStatus="icon" accountStatus="address" />;
       };
     }),
   { ssr: false }

--- a/apps/web/src/components/GiftFeed.tsx
+++ b/apps/web/src/components/GiftFeed.tsx
@@ -13,14 +13,24 @@ interface GiftRecord {
 
 function timeAgo(ts: number): string {
   const seconds = Math.floor((Date.now() - ts) / 1000);
-  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
+  if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);
-  return `${hours}h`;
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
 
-export function GiftFeed() {
+const PLATFORM_DISPLAY: Record<string, string> = {
+  spotify: "spotify",
+  soundcloud: "soundcloud",
+  bandcamp: "bandcamp",
+  "youtube-music": "yt music",
+  subcult: "subcult",
+};
+
+export function GiftFeed({ limit = 6 }: { limit?: number }) {
   const [gifts, setGifts] = useState<GiftRecord[]>([]);
 
   useEffect(() => {
@@ -41,42 +51,61 @@ export function GiftFeed() {
     };
   }, []);
 
-  if (gifts.length === 0) {
-    return (
-      <div className="py-6 text-ink-faint text-sm">
-        nothing yet. play music with the extension installed.
-      </div>
-    );
-  }
-
   return (
     <div>
-      {gifts.slice(0, 10).map((gift, i) => (
-        <div
-          key={`${gift.timestamp}-${i}`}
-          className="flex items-baseline justify-between py-3 border-b border-rule last:border-0"
-        >
-          <div className="min-w-0 mr-4">
-            <span className="font-bold">{gift.artist}</span>
-            <span className="text-ink-faint text-sm ml-2">{gift.track}</span>
-          </div>
-          <div className="flex items-baseline gap-3 shrink-0 text-sm">
-            {gift.txHash ? (
-              <a
-                href={`https://testnet.arcscan.app/tx/${gift.txHash}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-onda font-bold font-mono hover:underline"
-              >
-                ${gift.amount?.toFixed(2) || "0.01"}
-              </a>
-            ) : (
-              <span className="font-mono">${gift.amount?.toFixed(2) || "0.01"}</span>
-            )}
-            <span className="text-ink-faint text-xs">{timeAgo(gift.timestamp)}</span>
-          </div>
+      <div className="flex items-baseline justify-between mb-4">
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint">
+          recent tips
         </div>
-      ))}
+        <span className="text-[10px] font-mono uppercase tracking-widest text-ink-faint hover:text-onda transition-colors cursor-default">
+          live feed →
+        </span>
+      </div>
+
+      {gifts.length === 0 ? (
+        <div className="py-6 text-ink-faint text-sm">
+          nothing yet. play music with the extension installed.
+        </div>
+      ) : (
+        <div>
+          {gifts.slice(0, limit).map((gift, i) => (
+            <div
+              key={`${gift.timestamp}-${i}`}
+              className="grid items-baseline py-3 border-t border-rule first:border-t-0"
+              style={{
+                gridTemplateColumns: "70px 1fr 100px 70px",
+                gap: 12,
+              }}
+            >
+              <span className="text-xs font-mono text-ink-faint">
+                {timeAgo(gift.timestamp)}
+              </span>
+              <span className="text-sm truncate">
+                <span className="text-ink-light">{gift.track}</span>
+                <span className="text-ink-faint"> · </span>
+                <span className="font-bold lowercase">{gift.artist}</span>
+              </span>
+              <span className="text-xs text-ink-faint lowercase truncate">
+                {PLATFORM_DISPLAY[gift.platform] || gift.platform}
+              </span>
+              {gift.txHash ? (
+                <a
+                  href={`https://testnet.arcscan.app/tx/${gift.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-sm font-bold text-onda hover:underline text-right"
+                >
+                  +${(gift.amount || 0.01).toFixed(2)}
+                </a>
+              ) : (
+                <span className="font-mono text-sm font-bold text-onda text-right">
+                  +${(gift.amount || 0.01).toFixed(2)}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/ListeningActivity.tsx
+++ b/apps/web/src/components/ListeningActivity.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 interface GiftRecord {
   artist: string;
@@ -13,6 +13,7 @@ interface GiftRecord {
 
 interface DayData {
   label: string;
+  date: number;
   count: number;
   amount: number;
 }
@@ -20,23 +21,26 @@ interface DayData {
 function getLast7Days(gifts: GiftRecord[]): DayData[] {
   const days: DayData[] = [];
   const now = new Date();
-
   for (let i = 6; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
     const dayStart = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
     const dayEnd = dayStart + 86400000;
-
     const dayGifts = gifts.filter((g) => g.timestamp >= dayStart && g.timestamp < dayEnd);
     days.push({
       label: d.toLocaleDateString("en", { weekday: "short" }).toLowerCase(),
+      date: d.getDate(),
       count: dayGifts.length,
       amount: dayGifts.reduce((sum, g) => sum + (g.amount || 0.01), 0),
     });
   }
-
   return days;
 }
+
+const FULL_DAY: Record<string, string> = {
+  sun: "sunday", mon: "monday", tue: "tuesday", wed: "wednesday",
+  thu: "thursday", fri: "friday", sat: "saturday",
+};
 
 export function ListeningActivity() {
   const [gifts, setGifts] = useState<GiftRecord[]>([]);
@@ -53,58 +57,71 @@ export function ListeningActivity() {
     return () => window.removeEventListener("message", handler);
   }, []);
 
-  const days = getLast7Days(gifts);
-  const maxCount = Math.max(...days.map((d) => d.count), 1);
+  const days = useMemo(() => getLast7Days(gifts), [gifts]);
+  const total = days.reduce((s, d) => s + d.count, 0);
+  const avg = total / Math.max(days.length, 1);
+  const max = Math.max(...days.map((d) => d.count), 1);
+  const bestIdx = days.reduce((best, d, i) => (d.count > days[best].count ? i : best), 0);
+  const bestDay = days[bestIdx];
+
+  const headline =
+    total === 0
+      ? "no waves yet — listen to something."
+      : bestDay && bestDay.count > 0
+        ? `${total} wave${total === 1 ? "" : "s"} sent — `
+        : `${total} wave${total === 1 ? "" : "s"} sent.`;
 
   return (
-    <div className="mb-12">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xs uppercase tracking-widest text-ink-faint">activity</h2>
-        <span className="text-xs text-ink-faint font-mono">
-          {gifts.length} gift{gifts.length !== 1 ? "s" : ""} total
-        </span>
+    <section className="border-t border-b border-rule py-10">
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint">
+          activity · last 7 days
+        </div>
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint">
+          daily average · {avg.toFixed(1)}
+        </div>
       </div>
 
-      <div className="flex items-end gap-2 h-28">
-        {days.map((day, i) => {
-          const height = maxCount > 0 ? (day.count / maxCount) * 100 : 0;
-          const isToday = i === days.length - 1;
+      <h2 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight mb-8">
+        {headline}
+        {bestDay && bestDay.count > 0 && (
+          <span className="onda-serif-italic text-onda">
+            {FULL_DAY[bestDay.label]} was a good day.
+          </span>
+        )}
+      </h2>
 
+      <div className="grid grid-cols-7 gap-3 items-end" style={{ minHeight: 220 }}>
+        {days.map((day, i) => {
+          const heightPct = max > 0 ? (day.count / max) * 100 : 0;
+          const isBest = i === bestIdx && day.count > 0;
           return (
-            <div key={day.label} className="flex-1 flex flex-col items-center gap-2">
-              <div className="w-full flex items-end justify-center" style={{ height: "80px" }}>
-                {day.count > 0 ? (
-                  <div
-                    className={`w-full max-w-[44px] transition-all duration-300 ${
-                      isToday ? "bg-onda" : "bg-ink/15"
-                    }`}
-                    style={{ height: `${Math.max(height, 6)}%` }}
-                    title={`${day.count} gift${day.count !== 1 ? "s" : ""} — $${day.amount.toFixed(2)}`}
-                  />
-                ) : (
-                  <div
-                    className="w-full max-w-[44px] bg-rule/40"
-                    style={{ height: "2px" }}
-                  />
-                )}
+            <div key={`${day.label}-${i}`} className="flex flex-col items-center">
+              <div className="text-[11px] font-mono text-ink-faint mb-1 h-4">
+                {day.count > 0 ? day.count : ""}
               </div>
-              <span
-                className={`text-[10px] font-mono ${
-                  isToday ? "text-onda font-bold" : "text-ink-faint"
-                }`}
+              <div className="w-full flex items-end" style={{ height: 180 }}>
+                <div
+                  className="w-full transition-all duration-500"
+                  style={{
+                    height: `${Math.max(heightPct, day.count > 0 ? 8 : 2)}%`,
+                    background: isBest
+                      ? "var(--onda-rust, #B8621B)"
+                      : "var(--onda-faded, #CFC6B6)",
+                  }}
+                  title={`${day.count} wave${day.count === 1 ? "" : "s"} — $${day.amount.toFixed(2)}`}
+                />
+              </div>
+              <div
+                className={`text-xs font-mono mt-3 ${isBest ? "text-onda font-bold" : "text-ink-faint"}`}
               >
                 {day.label}
-              </span>
+              </div>
+              <div className="text-[10px] font-mono text-ink-faint">{day.date}</div>
             </div>
           );
         })}
       </div>
-
-      {gifts.length === 0 && (
-        <div className="text-center text-ink-faint text-xs mt-4">
-          play music with the extension to see your activity here.
-        </div>
-      )}
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/components/TopArtists.tsx
+++ b/apps/web/src/components/TopArtists.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { ArtistConnect } from "./dashboard/ArtistConnect";
 
 interface GiftRecord {
   artist: string;
@@ -19,20 +20,18 @@ interface ArtistStat {
 
 function aggregateArtists(gifts: GiftRecord[]): ArtistStat[] {
   const map = new Map<string, { gifts: number; amount: number }>();
-
   for (const gift of gifts) {
     const existing = map.get(gift.artist) || { gifts: 0, amount: 0 };
     existing.gifts += 1;
     existing.amount += gift.amount || 0.01;
     map.set(gift.artist, existing);
   }
-
   return Array.from(map.entries())
     .map(([name, data]) => ({ name, ...data }))
     .sort((a, b) => b.gifts - a.gifts);
 }
 
-export function TopArtists() {
+export function TopArtists({ limit = 6 }: { limit?: number }) {
   const [gifts, setGifts] = useState<GiftRecord[]>([]);
 
   useEffect(() => {
@@ -48,53 +47,60 @@ export function TopArtists() {
   }, []);
 
   const artists = aggregateArtists(gifts);
-  const topArtists = artists.slice(0, 5);
-  const maxGifts = topArtists[0]?.gifts || 1;
+  const top = artists.slice(0, limit);
+  const max = top[0]?.gifts || 1;
 
   return (
     <div>
-      <h2 className="text-xs uppercase tracking-widest text-ink-faint mb-4">top artists</h2>
-      {topArtists.length === 0 ? (
-        <div className="py-4 text-ink-faint text-sm">
+      <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint mb-5">
+        top artists · this month
+      </div>
+
+      {top.length === 0 ? (
+        <div className="py-6 text-ink-faint text-sm">
           your most-supported artists will appear here.
         </div>
       ) : (
-        <div className="space-y-3">
-          {topArtists.map((artist, i) => {
-            const barWidth = (artist.gifts / maxGifts) * 100;
-
+        <ul className="space-y-0">
+          {top.map((artist, i) => {
+            const pct = (artist.gifts / max) * 100;
             return (
-              <div key={artist.name}>
-                <div className="flex items-center justify-between mb-1">
-                  <div className="flex items-center gap-2.5">
-                    <span className="text-xs font-mono text-ink-faint w-4 text-right">
-                      {i + 1}
-                    </span>
-                    <span className="text-sm font-bold truncate max-w-[180px]">
-                      {artist.name}
-                    </span>
+              <li
+                key={artist.name}
+                className="border-t border-rule first:border-t-0 py-4"
+              >
+                <div className="flex items-baseline gap-3">
+                  <span className="font-mono text-[11px] text-ink-faint w-6">
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-bold truncate">{artist.name}</div>
                   </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-xs text-ink-faint">
-                      {artist.gifts}x
-                    </span>
-                    <span className="font-mono text-xs font-bold text-onda">
-                      ${artist.amount.toFixed(2)}
-                    </span>
-                  </div>
+                  <span className="font-mono text-xs text-ink-faint w-12 text-right">
+                    {artist.gifts}×
+                  </span>
+                  <span className="font-mono text-sm font-bold text-onda w-16 text-right">
+                    ${artist.amount.toFixed(2)}
+                  </span>
                 </div>
-                <div className="h-1 bg-rule/40 overflow-hidden" style={{ marginLeft: "26px" }}>
+                {/* Rust progress line */}
+                <div
+                  className="h-[2px] bg-rule/50 mt-2.5 overflow-hidden"
+                  style={{ marginLeft: 36 }}
+                >
                   <div
-                    className={`h-full transition-all duration-500 ${
-                      i === 0 ? "bg-onda" : "bg-ink/15"
-                    }`}
-                    style={{ width: `${barWidth}%` }}
+                    className="h-full bg-onda transition-all duration-500"
+                    style={{ width: `${pct}%` }}
                   />
                 </div>
-              </div>
+                {/* Connect popover */}
+                <div style={{ marginLeft: 36, marginTop: 6 }}>
+                  <ArtistConnect artistName={artist.name} />
+                </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
       )}
     </div>
   );

--- a/apps/web/src/components/dashboard/ArtistConnect.tsx
+++ b/apps/web/src/components/dashboard/ArtistConnect.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { searchArtist, getArtistDetails, getArtistUrls } from "@/lib/musicbrainz";
+
+interface ArtistConnectProps {
+  artistName: string;
+}
+
+type Status = "idle" | "loading" | "ready" | "empty" | "error";
+
+const PLATFORM_LABELS: Record<string, string> = {
+  spotify: "spotify",
+  bandcamp: "bandcamp",
+  soundcloud: "soundcloud",
+  youtube: "yt music",
+  website: "website",
+};
+
+export function ArtistConnect({ artistName }: ArtistConnectProps) {
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [urls, setUrls] = useState<Record<string, string>>({});
+  const [mbid, setMbid] = useState<string>("");
+
+  const load = async () => {
+    if (status === "ready" || status === "loading") return;
+    setStatus("loading");
+    try {
+      const matches = await searchArtist(artistName);
+      const top = matches[0];
+      if (!top) {
+        setStatus("empty");
+        return;
+      }
+      setMbid(top.id);
+      const details = await getArtistDetails(top.id);
+      const found = getArtistUrls(details.relations);
+      setUrls(found);
+      setStatus(Object.keys(found).length === 0 ? "empty" : "ready");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next) load();
+  };
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="text-[10px] font-mono uppercase tracking-widest text-ink-faint hover:text-onda transition-colors"
+      >
+        {open ? "hide ↑" : "connect ↓"}
+      </button>
+      {open && (
+        <div
+          style={{
+            marginTop: 8,
+            padding: "10px 12px",
+            background: "var(--onda-paper-2, #E3DCCD)",
+            border: "1px solid var(--onda-line, rgba(13,13,13,0.12))",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          {status === "loading" && (
+            <span className="text-xs text-ink-faint font-mono">looking up…</span>
+          )}
+          {status === "error" && (
+            <span className="text-xs text-ink-faint font-mono">couldn't reach musicbrainz</span>
+          )}
+          {status === "empty" && (
+            <span className="text-xs text-ink-faint font-mono">no public links found on musicbrainz</span>
+          )}
+          {status === "ready" && (
+            <>
+              {Object.entries(urls).map(([key, href]) => (
+                <a
+                  key={key}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs px-2.5 py-1 border border-ink/40 hover:border-onda hover:text-onda transition-colors lowercase"
+                >
+                  {PLATFORM_LABELS[key] ?? key}
+                </a>
+              ))}
+              {mbid && (
+                <a
+                  href={`https://musicbrainz.org/artist/${mbid}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] font-mono uppercase tracking-widest text-ink-faint hover:text-onda transition-colors ml-auto"
+                >
+                  musicbrainz ↗
+                </a>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/Sparkline.tsx
+++ b/apps/web/src/components/dashboard/Sparkline.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+interface SparklineProps {
+  values: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export function Sparkline({
+  values,
+  width = 320,
+  height = 80,
+  className,
+}: SparklineProps) {
+  if (values.length === 0) {
+    return (
+      <svg width={width} height={height} className={className} aria-hidden="true">
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke="var(--onda-line, rgba(13,13,13,0.12))"
+          strokeWidth={1}
+          strokeDasharray="2 4"
+        />
+      </svg>
+    );
+  }
+
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const range = Math.max(max - min, 1);
+  const step = values.length > 1 ? width / (values.length - 1) : 0;
+
+  const points = values
+    .map((v, i) => {
+      const x = i * step;
+      const y = height - ((v - min) / range) * (height - 8) - 4;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+
+  // smooth path via Catmull-Rom-ish curve
+  const coords = points.split(" ").map((p) => p.split(",").map(Number) as [number, number]);
+  let d = `M ${coords[0][0]} ${coords[0][1]}`;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const [x0, y0] = coords[i];
+    const [x1, y1] = coords[i + 1];
+    const cx = (x0 + x1) / 2;
+    d += ` C ${cx} ${y0}, ${cx} ${y1}, ${x1} ${y1}`;
+  }
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <path
+        d={d}
+        fill="none"
+        stroke="var(--onda-rust, #B8621B)"
+        strokeOpacity={0.35}
+        strokeWidth={3}
+      />
+      <path
+        d={d}
+        fill="none"
+        stroke="var(--onda-ink, #0D0D0D)"
+        strokeWidth={1.25}
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/dashboard/TopUpPanel.tsx
+++ b/apps/web/src/components/dashboard/TopUpPanel.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { parseUnits } from "viem";
+import { USDC_ADDRESS, ERC20_ABI } from "@/lib/contracts";
+
+interface ExtensionWallet {
+  address: string;
+  usdcBalance: string;
+  escrowBalance: string;
+  error?: string;
+}
+
+interface TopUpPanelProps {
+  /** Called once with the extension wallet address as soon as it's detected. */
+  onWalletDetected?: (address: string) => void;
+}
+
+const PRESETS = [5, 10, 25];
+
+export function TopUpPanel({ onWalletDetected }: TopUpPanelProps) {
+  const { isConnected } = useAccount();
+  const [extWallet, setExtWallet] = useState<ExtensionWallet | null>(null);
+  const [detected, setDetected] = useState(false);
+  const [amount, setAmount] = useState<number>(10);
+
+  const { writeContract, data: hash, isPending, reset } = useWriteContract();
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.source !== window) return;
+      if (event.data?.type === "ONDA_WALLET_INFO") {
+        setDetected(true);
+        if (event.data.wallet?.address) {
+          setExtWallet(event.data.wallet);
+          onWalletDetected?.(event.data.wallet.address);
+        }
+      }
+    };
+    window.addEventListener("message", handler);
+    window.postMessage({ type: "ONDA_REQUEST_WALLET_INFO" }, "*");
+    const interval = setInterval(() => {
+      window.postMessage({ type: "ONDA_REQUEST_WALLET_INFO" }, "*");
+    }, 10000);
+    return () => {
+      window.removeEventListener("message", handler);
+      clearInterval(interval);
+    };
+  }, [onWalletDetected]);
+
+  const handleTopUp = () => {
+    if (!extWallet?.address) return;
+    writeContract({
+      address: USDC_ADDRESS,
+      abi: ERC20_ABI,
+      functionName: "transfer",
+      args: [extWallet.address as `0x${string}`, parseUnits(String(amount), 6)],
+    });
+  };
+
+  const buttonLabel = (() => {
+    if (isPending) return "confirm in wallet…";
+    if (isConfirming) return "topping up…";
+    if (isSuccess) return "topped up ✓";
+    return "top up balance ↑";
+  })();
+
+  const isDisabled = !isConnected || !extWallet?.address || isPending || isConfirming;
+
+  return (
+    <div
+      style={{
+        background: "var(--onda-paper-2, #E3DCCD)",
+        padding: 20,
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint mb-1">
+        balance running low?
+      </div>
+      <div className="text-xl sm:text-2xl font-bold tracking-tight leading-tight mb-5">
+        top up to keep
+        <br />
+        sending <span className="onda-serif-italic text-onda">waves.</span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        {PRESETS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => {
+              setAmount(p);
+              if (isSuccess) reset();
+            }}
+            className={`text-sm font-mono py-3 transition-colors ${
+              amount === p
+                ? "border-2 border-ink bg-paper"
+                : "border border-ink/20 bg-paper/50 hover:border-ink"
+            }`}
+          >
+            ${p}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleTopUp}
+        disabled={isDisabled}
+        className="bg-ink text-paper font-bold py-3.5 transition-opacity hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        {buttonLabel}
+      </button>
+
+      <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint text-center mt-3">
+        apple pay · card · direct deposit
+      </div>
+
+      {!detected && (
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint text-center mt-2">
+          waiting for extension…
+        </div>
+      )}
+      {detected && !isConnected && (
+        <div className="text-[10px] font-mono uppercase tracking-widest text-ink-faint text-center mt-2">
+          sign in to top up
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/design/README.md
+++ b/apps/web/src/design/README.md
@@ -1,0 +1,144 @@
+# onda design system
+
+Drop-in design primitives for the onda web app. Everything here is
+additive — nothing replaces existing code.
+
+## What's inside
+
+```
+design/
+├── tokens.css              # CSS custom properties (--onda-*) + keyframes
+├── motion.tsx              # Reveal, WordStagger, SplitReveal, MarqueeLine, CountUp
+└── marks/
+    ├── BreathingO.tsx      # The "O" as a living mark with a pulsing light
+    └── GenerativeWaveform.tsx  # Animated bar waveform inside a receipt card
+```
+
+## Install
+
+### 1. Token variables
+
+Add to `apps/web/src/app/globals.css` **after** the `@tailwind` imports:
+
+```css
+@import "../design/tokens.css";
+```
+
+(Or `@import "@/design/tokens.css"` depending on your alias setup.)
+
+All variables are namespaced `--onda-*` so they coexist with the
+existing `paper` / `ink` / `onda` Tailwind colors.
+
+### 2. Use the motion primitives
+
+Any component importing these needs the `"use client"` directive
+(they use `IntersectionObserver`):
+
+```tsx
+"use client";
+
+import { Reveal, WordStagger, SplitReveal, MarqueeLine } from "@/design/motion";
+
+export default function Hero() {
+  return (
+    <>
+      <Reveal>
+        <p className="onda-mono">live · tipping artists right now</p>
+      </Reveal>
+
+      <SplitReveal
+        as="h1"
+        tokens={[
+          "every play",
+          { br: true },
+          "sends a",
+          { br: true },
+          {
+            node: (
+              <span className="onda-serif-italic text-onda">wave.</span>
+            ),
+          },
+        ]}
+        step={80}
+        distance={40}
+        duration={1000}
+        className="text-7xl font-bold tracking-tight leading-[0.92] lowercase"
+      />
+
+      <MarqueeLine
+        text="every play sends a wave · direct to artists · no middlemen"
+        speed={60}
+      />
+    </>
+  );
+}
+```
+
+### 3. Use the marks
+
+```tsx
+import { BreathingO } from "@/design/marks/BreathingO";
+import { GenerativeWaveform } from "@/design/marks/GenerativeWaveform";
+
+<BreathingO width={240} />
+<GenerativeWaveform label="onda" amount="+ $0.01 → claire rousay" />
+```
+
+## Accessibility
+
+All animated components honour `prefers-reduced-motion: reduce`:
+
+- `Reveal` / `WordStagger` / `SplitReveal` reveal instantly (no slide).
+- `BreathingO` freezes into a static ring arrangement with full light.
+- `GenerativeWaveform` freezes on the first frame.
+- `.onda-live-dot` stops pulsing.
+
+No extra configuration needed.
+
+## Typography
+
+Two fonts beyond what's already loaded via Tailwind:
+
+| Family | Where to use |
+|--------|--------------|
+| `Inter` (existing) | Default body + headings |
+| `JetBrains Mono` (existing) | Labels, tickers, receipt chrome |
+| `Fraunces` (new) | Italic accent on a single word per heading — use `.onda-serif-italic` or the font-family directly |
+
+Add to your font loader (e.g. `app/layout.tsx`) if you don't already
+have Fraunces:
+
+```tsx
+import { Fraunces } from "next/font/google";
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  style: ["italic"],
+  weight: ["700"],
+  variable: "--font-fraunces",
+});
+
+// In <html className={`${fraunces.variable} ...`}>
+```
+
+Then tokens.css's `.onda-serif-italic` picks it up automatically.
+
+## Design DNA
+
+A single heading treatment drives the system:
+
+1. **Copy is always lowercase.** `every play sends a wave.`
+2. **One word per heading gets the Fraunces italic.** Usually the last
+   noun. Also coloured `var(--onda-rust)`.
+3. **Eyebrows above sections** are mono, 11 px, `letter-spacing: 2`,
+   coloured `var(--onda-muted-2)`.
+4. **Reveals stagger on scroll** — 45–90 ms per word is the sweet spot.
+5. **Marquees between sections** add continuous motion without being
+   obtrusive.
+
+## Next steps
+
+- Wire `BreathingO` into the nav `onda` wordmark for a living brand presence.
+- Replace the existing hero's `<span className="text-onda">wave.</span>`
+  with a `SplitReveal` to get the staggered entry.
+- Add a `<MarqueeLine>` below the dark stats bar as a section divider.

--- a/apps/web/src/design/marks/BreathingO.tsx
+++ b/apps/web/src/design/marks/BreathingO.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * BreathingO — the "O" as a living, breathing mark.
+ * Concentric elliptical rings pulse at different phases around a warm
+ * orange light at the centre that slowly fades in and out (~6s cycle).
+ *
+ * Use as an app-icon-style mark, or as a hero accent sitting next to
+ * the "nda" letterforms to spell "onda".
+ */
+
+import { CSSProperties, useEffect, useState } from "react";
+
+interface BreathingOProps {
+  /** Overall width in px. Default 360 (full lockup). */
+  width?: number;
+  /** Show the "nda" letterforms beside the mark. Default true. */
+  withLockup?: boolean;
+  /** Respect reduced-motion. Default true. */
+  respectReducedMotion?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function BreathingO({
+  width = 360,
+  withLockup = true,
+  respectReducedMotion = true,
+  className,
+  style,
+}: BreathingOProps) {
+  const [t, setT] = useState(0);
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (respectReducedMotion && typeof window !== "undefined") {
+      const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+      setReduced(mq.matches);
+      const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+      mq.addEventListener?.("change", handler);
+      return () => mq.removeEventListener?.("change", handler);
+    }
+  }, [respectReducedMotion]);
+
+  useEffect(() => {
+    if (reduced) return;
+    let raf: number;
+    const loop = () => {
+      setT(performance.now() / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [reduced]);
+
+  const pulse = reduced ? 1 : 0.25 + 0.75 * (0.5 + 0.5 * Math.sin((t * 2 * Math.PI) / 6));
+  const height = (140 / 360) * width;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={withLockup ? "0 0 360 140" : "0 0 110 140"}
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      <defs>
+        <radialGradient id="onda-breathing-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="var(--onda-rust-glow, #F4A160)" stopOpacity={pulse} />
+          <stop offset="45%" stopColor="var(--onda-rust, #B8621B)" stopOpacity={pulse * 0.5} />
+          <stop offset="100%" stopColor="var(--onda-rust, #B8621B)" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      {[0, 1, 2, 3, 4].map((i) => {
+        const phase = t * 1.2 + i * 0.7;
+        const rx = 30 + Math.sin(phase) * (6 + i * 2);
+        const ry = 30 + Math.cos(phase * 1.3) * (6 + i * 2);
+        return (
+          <ellipse
+            key={i}
+            cx="52"
+            cy="72"
+            rx={reduced ? 30 + i * 4 : rx}
+            ry={reduced ? 30 + i * 4 : ry}
+            fill="none"
+            stroke="var(--onda-ink, #0D0D0D)"
+            strokeOpacity={0.2 + (4 - i) * 0.15}
+            strokeWidth="1.5"
+          />
+        );
+      })}
+      {/* Warm glow halo */}
+      <circle cx="52" cy="72" r="26" fill="url(#onda-breathing-glow)" />
+      {/* Central light */}
+      <circle
+        cx="52"
+        cy="72"
+        r={3 + pulse * 1.5}
+        fill="var(--onda-rust-glow, #F4A160)"
+        fillOpacity={pulse}
+      />
+      <circle
+        cx="52"
+        cy="72"
+        r="2"
+        fill="#FFE4C9"
+        fillOpacity={0.6 + pulse * 0.4}
+      />
+      {withLockup && (
+        <text
+          x="110"
+          y="104"
+          fontSize="90"
+          fontWeight="800"
+          fontFamily="Inter, system-ui, sans-serif"
+          letterSpacing="-2"
+          fill="var(--onda-ink, #0D0D0D)"
+        >
+          nda
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/design/marks/GenerativeWaveform.tsx
+++ b/apps/web/src/design/marks/GenerativeWaveform.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * GenerativeWaveform — animated bar-style waveform inside a receipt card.
+ * Each render plays a unique-looking wave driven by layered sine harmonics.
+ *
+ * Good for: hero accents, "now playing" chrome, transaction receipts,
+ * anywhere a track is playing or a tip has just landed.
+ */
+
+import { CSSProperties, useEffect, useState } from "react";
+
+interface GenerativeWaveformProps {
+  /** Show the surrounding receipt frame (mono header + label footer). Default true. */
+  framed?: boolean;
+  /** Number of bars. Default 80. */
+  bars?: number;
+  /** Width in px. Default 260. Height scales with it. */
+  width?: number;
+  /** Track label to render in the footer when framed. */
+  label?: string;
+  /** Tip amount label to render in the footer when framed. */
+  amount?: string;
+  /** Respect reduced-motion (freezes the bars). Default true. */
+  respectReducedMotion?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function GenerativeWaveform({
+  framed = true,
+  bars = 80,
+  width = 260,
+  label = "onda",
+  amount = "+ $0.01",
+  respectReducedMotion = true,
+  className,
+  style,
+}: GenerativeWaveformProps) {
+  const [t, setT] = useState(0);
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (respectReducedMotion && typeof window !== "undefined") {
+      const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+      setReduced(mq.matches);
+      const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+      mq.addEventListener?.("change", handler);
+      return () => mq.removeEventListener?.("change", handler);
+    }
+  }, [respectReducedMotion]);
+
+  useEffect(() => {
+    if (reduced) return;
+    let raf: number;
+    const loop = () => {
+      setT(performance.now() / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [reduced]);
+
+  const W = width;
+  const H = Math.round(width * (90 / 260));
+  const values: number[] = [];
+  for (let i = 0; i < bars; i++) {
+    const v =
+      0.2 +
+      0.4 * Math.abs(Math.sin(i * 0.35 + t * 1.3)) +
+      0.4 * Math.abs(Math.sin(i * 0.12 + t * 0.6));
+    values.push(v);
+  }
+
+  const svg = (
+    <svg
+      width="100%"
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      {values.map((v, i) => (
+        <rect
+          key={i}
+          x={i * (W / bars)}
+          y={H / 2 - (v * H) / 2}
+          width={W / bars - 0.5}
+          height={v * H}
+          fill={i % 7 === 0 ? "var(--onda-rust, #B8621B)" : "var(--onda-ink, #0D0D0D)"}
+        />
+      ))}
+    </svg>
+  );
+
+  if (!framed) {
+    return (
+      <div className={className} style={{ width: "100%", ...style }}>
+        {svg}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      style={{
+        background: "var(--onda-paper-2, #E3DCCD)",
+        border: "1.5px dashed var(--onda-ink, #0D0D0D)",
+        padding: 16,
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "JetBrains Mono, monospace",
+          fontSize: 10,
+          letterSpacing: 1.4,
+          color: "var(--onda-muted-2, #6B655B)",
+          marginBottom: 8,
+          display: "flex",
+          justifyContent: "space-between",
+          textTransform: "lowercase",
+        }}
+      >
+        <span>ONDA · TX</span>
+        <span>·842·7a9</span>
+      </div>
+      {svg}
+      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8 }}>
+        <div style={{ fontWeight: 800, fontSize: 22, letterSpacing: -0.6 }}>
+          {label}
+        </div>
+        <div
+          style={{
+            fontFamily: "JetBrains Mono, monospace",
+            fontSize: 10,
+            color: "var(--onda-muted-2, #6B655B)",
+          }}
+        >
+          {amount}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/design/marks/WaveMark.tsx
+++ b/apps/web/src/design/marks/WaveMark.tsx
@@ -1,0 +1,61 @@
+/**
+ * WaveMark — small static sine-wave glyph + "onda" wordmark.
+ * Sized for nav bars and inline uses; not animated.
+ */
+
+import { CSSProperties } from "react";
+
+interface WaveMarkProps {
+  /** Pixel height of the mark. Default 22 (sized for a 56px nav). */
+  height?: number;
+  /** Render only the wave glyph, no wordmark. Default false. */
+  glyphOnly?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function WaveMark({
+  height = 22,
+  glyphOnly = false,
+  className,
+  style,
+}: WaveMarkProps) {
+  // viewBox is sized so glyph is ~28w x 16h, wordmark ~70w
+  const vbW = glyphOnly ? 32 : 110;
+  const vbH = 24;
+  const width = (vbW / vbH) * height;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${vbW} ${vbH}`}
+      className={className}
+      style={{ display: "block", ...style }}
+      aria-label="onda"
+      role="img"
+    >
+      <path
+        d="M2 12 C 6 4, 10 4, 14 12 S 22 20, 26 12"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {!glyphOnly && (
+        <text
+          x="36"
+          y="18"
+          fontSize="18"
+          fontWeight="800"
+          fontFamily="Inter, system-ui, sans-serif"
+          letterSpacing="-0.6"
+          fill="currentColor"
+        >
+          onda
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/design/motion.tsx
+++ b/apps/web/src/design/motion.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+/**
+ * Onda motion primitives — scroll-triggered reveals + continuous marquees.
+ *
+ * All components are:
+ *   - zero-dependency (only React + IntersectionObserver)
+ *   - reduced-motion aware (auto-disables animations)
+ *   - client-only — mark the importing file with `"use client"` in app router
+ *
+ * Usage:
+ *   import { Reveal, WordStagger, SplitReveal, MarqueeLine, CountUp } from "@/design/motion";
+ */
+
+import {
+  CSSProperties,
+  ElementType,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+// ------------------------------------------------------------------
+// Hook
+// ------------------------------------------------------------------
+
+interface UseInViewOptions {
+  threshold?: number;
+  rootMargin?: string;
+  /** If false, the element un-reveals when it leaves the viewport. Default: true. */
+  once?: boolean;
+}
+
+export function useInView(
+  options: UseInViewOptions = {}
+): [React.RefObject<HTMLElement>, boolean] {
+  const ref = useRef<HTMLElement>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // Respect reduced motion → reveal immediately, skip animation.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setInView(true);
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          if (options.once !== false) io.unobserve(el);
+        } else if (options.once === false) {
+          setInView(false);
+        }
+      },
+      {
+        threshold: options.threshold ?? 0.15,
+        rootMargin: options.rootMargin ?? "0px 0px -80px 0px",
+      }
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, [options.once, options.threshold, options.rootMargin]);
+
+  return [ref, inView];
+}
+
+// ------------------------------------------------------------------
+// <Reveal>
+// ------------------------------------------------------------------
+
+interface RevealProps {
+  children: ReactNode;
+  delay?: number;
+  distance?: number;
+  duration?: number;
+  as?: ElementType;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function Reveal({
+  children,
+  delay = 0,
+  distance = 24,
+  duration = 900,
+  as: Tag = "div",
+  style,
+  className,
+  ...rest
+}: RevealProps) {
+  const [ref, inView] = useInView();
+  return (
+    <Tag
+      ref={ref as React.RefObject<HTMLElement>}
+      className={className}
+      style={{
+        ...style,
+        opacity: inView ? 1 : 0,
+        transform: inView ? "translateY(0)" : `translateY(${distance}px)`,
+        transition: `opacity ${duration}ms cubic-bezier(.2,.7,.2,1) ${delay}ms, transform ${duration}ms cubic-bezier(.2,.7,.2,1) ${delay}ms`,
+        willChange: "opacity, transform",
+      }}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+// ------------------------------------------------------------------
+// <WordStagger>
+// ------------------------------------------------------------------
+
+interface WordStaggerProps {
+  text: string;
+  delay?: number;
+  step?: number;
+  distance?: number;
+  duration?: number;
+  as?: ElementType;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function WordStagger({
+  text,
+  delay = 0,
+  step = 45,
+  distance = 20,
+  duration = 800,
+  as: Tag = "span",
+  style,
+  className,
+}: WordStaggerProps) {
+  const [ref, inView] = useInView();
+  const words = text.split(" ");
+  return (
+    <Tag
+      ref={ref as React.RefObject<HTMLElement>}
+      className={className}
+      style={{ ...style, display: "inline" }}
+    >
+      {words.map((w, i) => (
+        <span
+          key={i}
+          style={{
+            display: "inline-block",
+            overflow: "hidden",
+            verticalAlign: "top",
+          }}
+        >
+          <span
+            style={{
+              display: "inline-block",
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : `translateY(${distance}px)`,
+              transition: `opacity ${duration}ms cubic-bezier(.2,.7,.2,1) ${
+                delay + i * step
+              }ms, transform ${duration}ms cubic-bezier(.2,.7,.2,1) ${
+                delay + i * step
+              }ms`,
+            }}
+          >
+            {w}
+          </span>
+          {i < words.length - 1 ? "\u00A0" : ""}
+        </span>
+      ))}
+    </Tag>
+  );
+}
+
+// ------------------------------------------------------------------
+// <SplitReveal>
+// For headings with mixed children (line breaks, styled spans).
+// ------------------------------------------------------------------
+
+export type SplitToken =
+  | string
+  | { br: true }
+  | { node: ReactNode; space?: boolean };
+
+interface SplitRevealProps {
+  tokens: SplitToken[];
+  delay?: number;
+  step?: number;
+  distance?: number;
+  duration?: number;
+  as?: ElementType;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function SplitReveal({
+  tokens,
+  delay = 0,
+  step = 50,
+  distance = 26,
+  duration = 900,
+  as: Tag = "h2",
+  style,
+  className,
+}: SplitRevealProps) {
+  const [ref, inView] = useInView();
+  let idx = 0;
+  const out: ReactNode[] = [];
+
+  const spanStyle = (i: number): CSSProperties => ({
+    display: "inline-block",
+    opacity: inView ? 1 : 0,
+    transform: inView ? "translateY(0)" : `translateY(${distance}px)`,
+    transition: `opacity ${duration}ms cubic-bezier(.2,.7,.2,1) ${
+      delay + i * step
+    }ms, transform ${duration}ms cubic-bezier(.2,.7,.2,1) ${
+      delay + i * step
+    }ms`,
+  });
+
+  tokens.forEach((tok, ti) => {
+    if (typeof tok === "string") {
+      const words = tok.split(" ");
+      words.forEach((w, wi) => {
+        const i = idx++;
+        out.push(
+          <span
+            key={`s${ti}-${wi}`}
+            style={{
+              display: "inline-block",
+              overflow: "hidden",
+              verticalAlign: "bottom",
+            }}
+          >
+            <span style={spanStyle(i)}>{w}</span>
+            {wi < words.length - 1 ? "\u00A0" : ""}
+          </span>
+        );
+      });
+    } else if ("br" in tok) {
+      out.push(<br key={`br${ti}`} />);
+    } else {
+      const i = idx++;
+      out.push(
+        <span
+          key={`n${ti}`}
+          style={{
+            display: "inline-block",
+            overflow: "hidden",
+            verticalAlign: "bottom",
+          }}
+        >
+          <span style={spanStyle(i)}>{tok.node}</span>
+          {tok.space ? "\u00A0" : ""}
+        </span>
+      );
+    }
+  });
+
+  return (
+    <Tag
+      ref={ref as React.RefObject<HTMLElement>}
+      className={className}
+      style={style}
+    >
+      {out}
+    </Tag>
+  );
+}
+
+// ------------------------------------------------------------------
+// <MarqueeLine>
+// Continuously scrolling horizontal line. Ideal for section dividers.
+// ------------------------------------------------------------------
+
+interface MarqueeLineProps {
+  text: string;
+  /** Seconds for one full loop. Higher = slower. Default 30. */
+  speed?: number;
+  color?: string;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function MarqueeLine({
+  text,
+  speed = 30,
+  color = "var(--onda-muted-2)",
+  style,
+  className,
+}: MarqueeLineProps) {
+  const content = new Array(8).fill(text).join("  \u00B7  ");
+  return (
+    <div
+      className={className}
+      style={{ overflow: "hidden", whiteSpace: "nowrap", ...style }}
+    >
+      <div
+        style={{
+          display: "inline-block",
+          animation: `onda-marquee ${speed}s linear infinite`,
+          color,
+          fontFamily: "JetBrains Mono, monospace",
+          fontSize: 11,
+          letterSpacing: 2,
+          textTransform: "lowercase",
+          paddingRight: 40,
+        }}
+      >
+        {content}&nbsp;&nbsp;{content}
+      </div>
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------
+// <CountUp>
+// Number ticker that animates from 0 → value when visible.
+// ------------------------------------------------------------------
+
+interface CountUpProps {
+  value: number;
+  duration?: number;
+  prefix?: string;
+  suffix?: string;
+  decimals?: number;
+  style?: CSSProperties;
+  className?: string;
+}
+
+export function CountUp({
+  value,
+  duration = 1400,
+  prefix = "",
+  suffix = "",
+  decimals = 0,
+  style,
+  className,
+}: CountUpProps) {
+  const [ref, inView] = useInView();
+  const [n, setN] = useState(0);
+
+  useEffect(() => {
+    if (!inView) return;
+    let raf: number;
+    let start: number | undefined;
+    const tick = (t: number) => {
+      if (!start) start = t;
+      const p = Math.min(1, (t - start) / duration);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setN(value * eased);
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [inView, value, duration]);
+
+  return (
+    <span
+      ref={ref as React.RefObject<HTMLSpanElement>}
+      className={className}
+      style={style}
+    >
+      {prefix}
+      {n.toFixed(decimals)}
+      {suffix}
+    </span>
+  );
+}

--- a/apps/web/src/design/tokens.css
+++ b/apps/web/src/design/tokens.css
@@ -1,0 +1,87 @@
+/**
+ * Onda design tokens — extends the existing paper/ink/rust palette
+ * with the shades used in the new design exploration.
+ *
+ * Import this once at the top of `globals.css`:
+ *   @import "@/design/tokens.css";
+ *
+ * Every variable is namespaced under `--onda-*` to avoid collisions.
+ */
+
+:root {
+  /* Paper / ink */
+  --onda-paper: #ECE6DB;
+  --onda-paper-2: #E3DCCD;
+  --onda-ink: #0D0D0D;
+  --onda-ink-2: #1A1A1A;
+
+  /* Muted grays */
+  --onda-muted: #8A8378;
+  --onda-muted-2: #6B655B;
+  --onda-faded: #CFC6B6;
+
+  /* Accent (rust / onda orange) */
+  --onda-rust: #B8621B;
+  --onda-rust-ink: #8F4A12;
+  --onda-rust-glow: #F4A160;
+
+  /* Structural */
+  --onda-line: rgba(13, 13, 13, 0.12);
+  --onda-line-strong: rgba(13, 13, 13, 0.24);
+
+  /* Motion */
+  --onda-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --onda-reveal-duration: 900ms;
+  --onda-reveal-distance: 24px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Keyframes                                                          */
+/* ------------------------------------------------------------------ */
+
+@keyframes onda-blink {
+  0%, 100% { box-shadow: 0 0 0 4px rgba(184, 98, 27, 0.2); opacity: 1; }
+  50%      { box-shadow: 0 0 0 10px rgba(184, 98, 27, 0.05); opacity: 0.65; }
+}
+
+@keyframes onda-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+@keyframes onda-slide-in-right {
+  from { transform: translateX(20px); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+
+/* ------------------------------------------------------------------ */
+/* Utility classes                                                    */
+/* ------------------------------------------------------------------ */
+
+.onda-serif-italic {
+  font-family: "Fraunces", "Iowan Old Style", Georgia, serif;
+  font-style: italic;
+  font-weight: 700;
+  font-variation-settings: "SOFT" 100;
+}
+
+.onda-mono {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.onda-live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--onda-rust);
+  box-shadow: 0 0 0 4px rgba(184, 98, 27, 0.2);
+  animation: onda-blink 2.4s ease-in-out infinite;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .onda-live-dot {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Two commits on `new-design`:

1. **Design system + landing + dashboard** (`7767e10`) — adds `apps/web/src/design/` (tokens, motion, marks), ports the new editorial landing from the handoff bundle, and rebuilds the dashboard around the new visual language (wallet hero with sparkline, stat cards, 7-day chart, top-artists with MusicBrainz connect popover, recent-tips table, top-up panel). Also loads Fraunces italic and replaces the text "onda" wordmark with a small wave mark. RainbowKit avatar → truncated address.

2. **Extension popup + link bridge** (`06cf802`) — vanilla-js port of the OndaPopup design (inverted ink header, album-art tile, live bars, tip countdown, recent waves, footer). Adds the "connect →" affordance on the currently-playing artist (direct MusicBrainz lookup via added host permission). Fixes a load-bearing onboarding bug: when the user clicks *connect browser wallet*, Chrome closes the popup, which tears down `watchForJoin`, so Hypersync was the only detection path left — and it's unconfigured. The `/connect` page now posts `ONDA_LINK_DETECTED` on join-tx success; the content-script bridge forwards it as `SET_LINK`; the service worker validates session match, stores addresses, and broadcasts `LINKED` to any open popup. No Hypersync dependency in the common flow.

## Test plan

- [x] Landing: http://localhost:3000 renders new hero / wave / platform demo / ticker / spotlight / manifesto / FAQ / CTA. "i'm an artist" still links to `/claim` (modal is parked as follow-up).
- [x] Dashboard: http://localhost:3000/dashboard shows wallet hero, 3 stat cards, activity chart with editorial headline, top-artists (click `connect ↓` → platform pills appear), platforms breakdown, recent tips, top-up panel with $5/$10/$25 presets.
- [x] Extension popup (reload from `chrome://extensions` after `npm run build` in `apps/extension/`):
  - [ ] Onboarding: unlinked state shows new connect panel with QR fallback.
  - [x] Wallet link: click **connect browser wallet**, sign join tx → popup swaps to now-playing within a tick (no Hypersync needed).
  - [x] Scrobble: play a track → see listening eyebrow, live bars, tip countdown → on tip land, "wave sent $0.01" + arcscan link.
  - [x] Click **connect →** on now-playing → spotify / bandcamp / soundcloud / yt music / website pills appear, plus `MB ↗` deep link. Track change resets and closes the panel.

## Not in this PR (parked)

- The "i'm an artist" modal flow on the landing page (Option A plan).
- Pause button wiring in the service worker (popup toggles local state only).
- Album art extraction from content scripts (gradient placeholder).
- Prod-bundled Fraunces (currently Google Fonts at runtime).

## Caveats

- `apps/web/public/onda.zip` is not in this PR — rebuild from `apps/extension/` before publishing.
- Extension reauthorization prompt expected on update due to the new `musicbrainz.org` host permission. Pre-Store so no user impact.